### PR TITLE
Align syntax with EC r2022.04

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((easycrypt-mode .
+  ((eval .
+    (cl-flet ((pre (s) (concat (locate-dominating-file buffer-file-name ".dir-locals.el") s)))
+           (setq easycrypt-load-path `(,(pre "."), (pre "Core/"), (pre "du_mb_bpriv/VotingDefinition"))))))))

--- a/Core/HybridArg.ec
+++ b/Core/HybridArg.ec
@@ -139,8 +139,8 @@ clone import Means as M with
 (* -------------------------------------------------------------------- *)
 section.
 
-  declare module Ob <: Orclb    {Count,HybOrcl}.
-  declare module A  <: AdvOrclb {Count,HybOrcl,Ob}.
+  declare module Ob <: Orclb    { -Count, -HybOrcl }.
+  declare module A  <: AdvOrclb { -Count, -HybOrcl, -Ob}.
 
   (* Hybrid game where index is fixed, not sampled *)
   local module HybGameFixed (O : Orcl) = {
@@ -228,7 +228,7 @@ section.
   declare axiom losslessL: islossless Ob.leaks.
   declare axiom losslessOb1: islossless Ob.orclL.
   declare axiom losslessOb2: islossless Ob.orclR.
-  declare axiom losslessA (Ob0 <: Orclb{A}) (LR <: Orcl{A}):
+  declare axiom losslessA (Ob0 <: Orclb { -A }) (LR <: Orcl { -A }):
     islossless LR.orcl => 
     islossless Ob0.leaks => islossless Ob0.orclL => islossless Ob0.orclR =>
     islossless A(Ob0, LR).main.

--- a/Core/VFR.ec
+++ b/Core/VFR.ec
@@ -63,7 +63,7 @@ clone export ProofSystem as PSvf with
 
 (* VFR adversary *)
 module type VFR_Adv(H: PKEvf.POracle, G: PSvf.POracle) ={
-  proc main(pk: pkey)  : ( label * cipher) list { H.o G.o} 
+  proc main(pk: pkey)  : ( label * cipher) list { H.o, G.o} 
 }.
 
 (*** Overwrite the Relation in Proof System to one of the following ***)

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ In addition, we model the [*mb-bpriv* ballot privacy definition](https://eprint.
   *  The [`mb_bpriv_orignal_def`](https://github.com/mortensol/du-mb-bpriv/tree/main/mb_bpriv_original_def) folder contains an EasyCrypt model of the mb-bpriv ballot privacy definition and proofs that Labelled-MiniVoting and Belenios satisfy this definition
 
 #### Installing EasyCrypt
-We refer to https://github.com/EasyCrypt/easycrypt for instructions on how to install EasyCrypt. 
+We refer to https://github.com/EasyCrypt/easycrypt for instructions on how to install EasyCrypt.
+This proof is known to check with EasyCrypt stable release `r2022.04`, using Z3 4.8.10, Alt-Ergo 2.4.1, and CVC4 1.8.

--- a/config/tests.config
+++ b/config/tests.config
@@ -13,6 +13,10 @@ args   = -I Core
 okdirs = du_mb_bpriv/Selene
 args   = -I Core -I du_mb_bpriv/VotingDefinition
 
+[test-dumb-selene-with-signatures]
+okdirs = du_mb_bpriv/Selene_with_signatures
+args   = -I Core -I du_mb_bpriv/VotingDefinition
+
 [test-dumb-belenios]
 okdirs = du_mb_bpriv/Belenios_and_MiniVoting
 args   = -I Core -I du_mb_bpriv/VotingDefinition

--- a/config/tests.config
+++ b/config/tests.config
@@ -5,11 +5,18 @@ args =
 [test-core]
 okdirs = Core
 
+[test-dumb-defs]
+okdirs = du_mb_bpriv/VotingDefinition
+args   = -I Core
+
 [test-dumb-selene]
 okdirs = du_mb_bpriv/Selene
+args   = -I Core -I du_mb_bpriv/VotingDefinition
 
 [test-dumb-belenios]
-okdirs = du_mb_bprove/Belenios_and_MiniVoting
+okdirs = du_mb_bpriv/Belenios_and_MiniVoting
+args   = -I Core -I du_mb_bpriv/VotingDefinition
 
 [test-mb-bpriv]
 okdirs = mb_bpriv_original_def
+args   = -I Core

--- a/du_mb_bpriv/Belenios_and_MiniVoting/Belenios.ec
+++ b/du_mb_bpriv/Belenios_and_MiniVoting/Belenios.ec
@@ -100,7 +100,7 @@ clone export MiniVotingSecurity_mb as MV2 with
 
 
 (* Labelled Public-Key Encryption Scheme  *)
-  module (IPKE(P: PSpke.Prover, Ve: PSpke.Verifier): Scheme) (O:HOracle.POracle) = {
+module (IPKE(P: PSpke.Prover, Ve: PSpke.Verifier): Scheme) (O:HOracle.POracle) = {
     
     proc kgen(): pkey * skey ={
       var sk; 

--- a/du_mb_bpriv/Belenios_and_MiniVoting/Belenios.ec
+++ b/du_mb_bpriv/Belenios_and_MiniVoting/Belenios.ec
@@ -154,18 +154,18 @@ module (Belenios (Pe: PSpke.Prover, Ve: PSpke.Verifier, Vc: PSpke.Verifier,
 
 section DU_MB_BPRIV. 
 
-declare module Pe <: PSpke.Prover    {BP, HRO.ERO, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv}.
-declare module Ve <: PSpke.Verifier  {BP, HRO.ERO, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv, Pe}.
-declare module Vc <: PSpke.Verifier  {BP, HRO.ERO, BPS, BS, Pe, Ve}.
+declare module Pe <: PSpke.Prover    { -BP, -HRO.ERO, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv }.
+declare module Ve <: PSpke.Verifier  { -BP, -HRO.ERO, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv, -Pe }.
+declare module Vc <: PSpke.Verifier  { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve }.
 
-declare module G  <: GOracle.Oracle  {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc}.   
-declare module S  <: Simulator       {BP, HRO.ERO, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv, 
-                                     Pe, Ve, Vc, G}. 
-declare module Vz <: Verifier        {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S}. 
-declare module Pz <: Prover          {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S, Vz}. 
-declare module R  <: VotingRelation' {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S, Vz, Pz}. 
+declare module G  <: GOracle.Oracle  { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc }.   
+declare module S  <: Simulator       { -BP, -HRO.ERO, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv, 
+                                       -Pe, -Ve, -Vc, -G }. 
+declare module Vz <: Verifier        { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S }.
+declare module Pz <: Prover          { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S, -Vz }.
+declare module R  <: VotingRelation' { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S, -Vz, -Pz }.
  
-declare module A  <: DU_MB_BPRIV_adv    {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S, Vz, Pz, R}. 
+declare module A  <: DU_MB_BPRIV_adv { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S, -Vz, -Pz, -R }. 
 
 (**** Lossless assumptions ****)
 
@@ -174,42 +174,42 @@ declare axiom Gi_ll : islossless G.init.
 declare axiom Go_ll : islossless G.o. 
 
 (** DU_MB-BPRIV adversary **)
-declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { A }):
+declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { -A }):
   islossless O.vote => 
   islossless O.board => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).create_bb. 
 
-declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.board => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).get_tally.
  
-declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.verify => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).final_guess. 
 
-declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).initial_guess. 
 
 (** Main Proof system **)
-declare axiom PS_p_ll (G <: GOracle.POracle {Pz} ) : 
+declare axiom PS_p_ll (G <: GOracle.POracle { -Pz } ) : 
   islossless G.o => islossless Pz(G).prove. 
-declare axiom PS_v_ll (G <: GOracle.POracle {Vz} ) : 
+declare axiom PS_v_ll (G <: GOracle.POracle { -Vz } ) : 
   islossless G.o => islossless Vz(G).verify. 
 
 (** Enc Proof system **)
-declare axiom PE_p_ll (H <: HOracle.POracle) : 
+declare axiom PE_p_ll (H <: HOracle.POracle { -Pe }) : 
   islossless H.o => islossless Pe(H).prove. 
-declare axiom PE_v_ll (H <: HOracle.POracle) : 
+declare axiom PE_v_ll (H <: HOracle.POracle { -Ve }) : 
   islossless H.o => islossless Ve(H).verify.
-declare axiom PE_c_ll (H <: HOracle.POracle) : 
+declare axiom PE_c_ll (H <: HOracle.POracle { -Vc }) : 
   islossless H.o => islossless Vc(H).verify.
 
 (** ZK simulator **)
@@ -268,7 +268,7 @@ declare axiom PS_p_verify_both (s: h_stm) (w: h_wit):
    /\ verify s res{1} HRO.ERO.m{1}].
 
 (** Encryption **)
-local lemma E_kg_ll  (H <: HOracle.POracle {IPKE(Pe, Ve)}) : 
+local lemma E_kg_ll  (H <: HOracle.POracle { -IPKE(Pe, Ve) }) : 
   islossless H.o => islossless IPKE(Pe,Ve,H).kgen.
 proof.
   move => Ho_ll. 
@@ -276,7 +276,7 @@ proof.
   by auto=>/>; rewrite FDistr.dt_ll.
 qed.
 
-local lemma E_enc_ll (H <: HOracle.POracle {IPKE(Pe, Ve)}) : 
+local lemma E_enc_ll (H <: HOracle.POracle { -IPKE(Pe, Ve) }) : 
   islossless H.o => islossless IPKE(Pe,Ve, H).enc. 
 proof.
   move => Ho_ll.
@@ -285,7 +285,7 @@ proof.
   by auto=>/>; rewrite FDistr.dt_ll.
 qed.
 
-local lemma E_dec_ll (H <: HOracle.POracle {IPKE(Pe, Ve)}) : 
+local lemma E_dec_ll (H <: HOracle.POracle { -IPKE(Pe, Ve) }) : 
   islossless H.o => islossless IPKE(Pe,Ve,H).dec. 
 proof.
   move => Ho_ll; proc.
@@ -295,7 +295,7 @@ qed.
  
 
 (** ValidInd operator **)
-local lemma C_vi_ll (H <: HOracle.POracle {CV(Vc)}) : 
+local lemma C_vi_ll (H <: HOracle.POracle { -CV(Vc) }) : 
   islossless H.o => islossless CV(Vc,H).validInd. 
 proof.
   move => Ho_ll; proc. 
@@ -309,13 +309,13 @@ local lemma Rho_weight (x: (ident * ptxt option) list):
   by rewrite /Rho dunit_ll.
 
 (*** linking key generation and extractPk operator ***)
-local lemma E_kgen_extractpk (H <: HOracle.POracle {IPKE(Pe, Ve)}):
+local lemma E_kgen_extractpk (H <: HOracle.POracle { -IPKE(Pe, Ve) }):
  equiv [IPKE(Pe,Ve,H).kgen ~ IPKE(Pe,Ve,H).kgen : ={glob H, glob IPKE(Pe,Ve)} 
         ==> ={glob H, glob  IPKE(Pe,Ve), res} /\ res{1}.`1 = getPK res{1}.`2] 
   by proc; auto.
 
 (*  stating that the keys are generated *)
-local lemma Ekgen_extractPk (H<: HOracle.POracle {IPKE(Pe, Ve)}):
+local lemma Ekgen_extractPk (H<: HOracle.POracle { -IPKE(Pe, Ve) }):
   equiv [IPKE(Pe,Ve, H).kgen ~ IPKE(Pe,Ve,H).kgen:  
     ={glob H, glob IPKE(Pe,Ve)}
     ==>
@@ -324,7 +324,7 @@ local lemma Ekgen_extractPk (H<: HOracle.POracle {IPKE(Pe, Ve)}):
       /\  res{1}.`1 = getPK res{1}.`2 ]
   by proc; auto.
 
-local lemma Ekgen_extractPk2  (H <: HOracle.POracle{IPKE(Pe, Ve)}):
+local lemma Ekgen_extractPk2  (H <: HOracle.POracle { -IPKE(Pe, Ve) }):
     hoare[ IPKE(Pe, Ve, H).kgen : true ==> res.`1 = getPK res.`2]
   by proc; auto. 
 

--- a/du_mb_bpriv/Belenios_and_MiniVoting/MiniVotingSecurity_mb.ec
+++ b/du_mb_bpriv/Belenios_and_MiniVoting/MiniVotingSecurity_mb.ec
@@ -21,19 +21,19 @@ clone FiniteEager as HRO.
 section DU_MB_BPRIV. 
 
 (** Random oracle **)
-declare module G  <: GOracle.Oracle { BP, HRO.ERO, BPS, BS }.
+declare module G  <: GOracle.Oracle { -BP, -HRO.ERO, -BPS, -BS }.
 (** Encryption scheme **)
-declare module E  <: Scheme { BP, HRO.ERO, G, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv}.
+declare module E  <: Scheme { -BP, -HRO.ERO, -G, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv}.
 (** Proof system **)
-declare module S  <: Simulator { BP, HRO.ERO, G, E, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv }.
-declare module Ve <: Verifier { BP, HRO.ERO, G, E, S, BPS, BS }.
-declare module P  <: Prover { BP, HRO.ERO, G, E, S, Ve, BPS, BS }.
-declare module R  <: VotingRelation' { BP, HRO.ERO, G, E, S, Ve, P, BPS, BS }.
+declare module S  <: Simulator { -BP, -HRO.ERO, -G, -E, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv }.
+declare module Ve <: Verifier { -BP, -HRO.ERO, -G, -E, -S, -BPS, -BS }.
+declare module P  <: Prover { -BP, -HRO.ERO, -G, -E, -S, -Ve, -BPS, -BS }.
+declare module R  <: VotingRelation' { -BP, -HRO.ERO, -G, -E, -S, -Ve, -P, -BPS, -BS }.
 (** Validity checker **)
-declare module C  <: ValidInd { BP, HRO.ERO, G, E, S, Ve, P, R, BPS, BS }.
+declare module C  <: ValidInd { -BP, -HRO.ERO, -G, -E, -S, -Ve, -P, -R, -BPS, -BS }.
 
 (** Adversary **)
-declare module A  <: DU_MB_BPRIV_adv { BP, HRO.ERO, G, E, S, Ve, P, R, C, BPS, BS}.
+declare module A  <: DU_MB_BPRIV_adv { -BP, -HRO.ERO, -G, -E, -S, -Ve, -P, -R, -C, -BPS, -BS }.
 
 (**** Lossless assumptions ****)
 
@@ -42,35 +42,35 @@ declare axiom Gi_ll : islossless G.init.
 declare axiom Go_ll : islossless G.o. 
 
 (** DU-MB-BPRIV adversary **)
-declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { A }):
+declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { -A }):
   islossless O.vote  => 
   islossless O.board => 
   islossless O.h     => 
   islossless O.g     => 
   islossless A(O).create_bb. 
-declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.board => 
   islossless O.h     => 
   islossless O.g     => 
   islossless A(O).get_tally. 
-declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.verify => 
   islossless O.h      => 
   islossless O.g      => 
   islossless A(O).final_guess. 
-declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).initial_guess. 
 
 (** Proof system **)
-declare axiom PS_p_ll (G <: GOracle.POracle { P })  : islossless G.o => islossless P(G).prove. 
-declare axiom PS_v_ll (G <: GOracle.POracle { Ve }) : islossless G.o => islossless Ve(G).verify. 
+declare axiom PS_p_ll (G <: GOracle.POracle { -P })  : islossless G.o => islossless P(G).prove. 
+declare axiom PS_v_ll (G <: GOracle.POracle { -Ve }) : islossless G.o => islossless Ve(G).verify. 
 
 (** Encryption **)
-declare axiom E_kg_ll  (H <: HOracle.POracle { E }) : islossless H.o => islossless E(H).kgen. 
-declare axiom E_enc_ll (H <: HOracle.POracle { E }) : islossless H.o => islossless E(H).enc. 
-declare axiom E_dec_ll (H <: HOracle.POracle { E }) : islossless H.o => islossless E(H).dec. 
+declare axiom E_kg_ll  (H <: HOracle.POracle { -E }) : islossless H.o => islossless E(H).kgen. 
+declare axiom E_enc_ll (H <: HOracle.POracle { -E }) : islossless H.o => islossless E(H).enc. 
+declare axiom E_dec_ll (H <: HOracle.POracle { -E }) : islossless H.o => islossless E(H).dec. 
 
 (** Encryption with HRO.ERO **)
 lemma E_kg_ll'  : islossless E(HRO.ERO).kgen by apply (E_kg_ll HRO.ERO HRO.ERO_o_ll). 
@@ -86,7 +86,7 @@ declare axiom Sp_ll : islossless S.prove.
 declare axiom R_m_ll : islossless R(E,HRO.ERO).main. 
 
 (** ValidInd operator **)
-declare axiom C_vi_ll (H <: HOracle.POracle { C }) : islossless H.o => islossless C(H).validInd. 
+declare axiom C_vi_ll (H <: HOracle.POracle { -C }) : islossless H.o => islossless C(H).validInd. 
 
 
 (****************************************************************************************************)
@@ -102,10 +102,10 @@ declare axiom Rho_weight x:
   weight (Rho x) = 1%r. 
 
 (* axiom linking key generation and getPK operator *)
-declare axiom E_kgen_getPK_hr (H <: HOracle.POracle { E }):
+declare axiom E_kgen_getPK_hr (H <: HOracle.POracle { -E }):
   hoare [E(H).kgen: true ==> res.`1 = getPK res.`2].
 
-equiv E_kgen_getPK (H <: HOracle.POracle { E }):
+equiv E_kgen_getPK (H <: HOracle.POracle { -E }):
   E(H).kgen ~ E(H).kgen : ={glob H, glob E} 
         ==> ={glob H, glob E, res} /\ res{1}.`1 = getPK res{1}.`2.
 proof. by conseq (: _ ==> ={glob H, glob E, res}) (E_kgen_getPK_hr H); sim. qed.
@@ -208,8 +208,8 @@ op rem_fst4 (x : ('a * 'b * 'c * 'd)) = (x.`2, x.`3, x.`4).
 
 (************ Construct a ZK adversary from du-mb-bpriv adversary *************)
 module type VotingAdvZK (H:HOracle.Oracle, O:GOracle.POracle) = {
-  proc a1() : (pkey * pubBB * result) * (skey * (label * cipher) list) {H.init H.o O.o}
-  proc a2(pi : prf option) : bool {H.o O.o}
+  proc a1() : (pkey * pubBB * result) * (skey * (label * cipher) list) {H.init, H.o, O.o}
+  proc a2(pi : prf option) : bool {H.o, O.o}
 }.
  
 
@@ -554,7 +554,7 @@ local module G0L' (E:Scheme, P:Prover, Ve:Verifier, C:ValidInd,
 }.
 
 (*** Lemma proving that G0L' is perfectly equivalent to the original definition ***)
-local lemma DU_MB_BPRIV_L_G0L'_equiv &m (H <: HOracle.Oracle{E, BP, G, A, C, Ve, P}) : 
+local lemma DU_MB_BPRIV_L_G0L'_equiv &m (H <: HOracle.Oracle{ -E, -BP, -G, -A, -C, -Ve, -P}) : 
   Pr[DU_MB_BPRIV_L(MV(E, P, Ve, C), A, H, G).main() @ &m : res] =
   Pr[G0L'(E,P,Ve,C,A,H,G).main() @ &m : res].
 proof. 
@@ -781,7 +781,7 @@ local module G1L (E:Scheme, Ve:Verifier, C:ValidInd,
 
 (*** Losslessness for BZK, useful in the ZK part a bit further down  ***)
 
-local lemma BZK_a1_ll (H <: HOracle.Oracle {E, BP, A}) (G <: GOracle.POracle {A}) : 
+local lemma BZK_a1_ll (H <: HOracle.Oracle { -E, -BP, -A }) (G <: GOracle.POracle { -A }) : 
   islossless H.init =>  
   islossless H.o => 
   islossless G.o => 
@@ -803,9 +803,9 @@ auto; call Hi_ll.
 by auto=> />; smt(Rho_weight).
 qed.
 
-lemma BZK_a2_ll' (H <: HOracle.Oracle {C, A}) 
-                 (G <: GOracle.POracle {Ve, A})
-                 (P <: Prover {A}) :
+lemma BZK_a2_ll' (H <: HOracle.Oracle { -C, -A }) 
+                 (G <: GOracle.POracle { -Ve, -A })
+                 (P <: Prover { -A }) :
   islossless H.o => 
   islossless G.o => 
   islossless P(G).prove =>
@@ -831,7 +831,7 @@ seq  1: true=> //.
 by sp; if=> //; auto; smt(DBool.dbool_ll).
 qed.
 
-lemma BZK_a2_ll (H <: HOracle.Oracle {C, A}) (G <: GOracle.POracle {P, Ve, A}) : 
+lemma BZK_a2_ll (H <: HOracle.Oracle { -C, -A }) (G <: GOracle.POracle { -P, -Ve, -A }) : 
   islossless H.o =>
   islossless G.o => 
   islossless BZK(E,P,C,Ve,A,H,G).a2.
@@ -926,9 +926,9 @@ qed.
 (*************** Lemma bounding the probability that the relation does not hold in ZK_L by ***************)
 (***************     the probability of returning true in the VFR game.                    ***************)
 
-local lemma ZKL_rel &m (H <: HOracle.Oracle {A, BPS, BP, BS, Ve, E, C, R})
-                       (G <: GOracle.Oracle {A, BPS, BP, BS, Ve, E, H, R, C})
-                       (P <: Prover {E, C, Ve, A, R, BPS, BP, BS, H, G}) :
+local lemma ZKL_rel &m (H <: HOracle.Oracle { -A, -BPS, -BP, -BS, -Ve, -E, -C, -R })
+                       (G <: GOracle.Oracle { -A, -BPS, -BP, -BS, -Ve, -E, -H, -R, -C })
+                       (P <: Prover { -E, -C, -Ve, -A, -R, -BPS, -BP, -BS, -H, -G }) :
   islossless H.o =>
   islossless G.o =>
   islossless P(G).prove =>
@@ -1086,8 +1086,8 @@ qed.
 (********** Lemma bounding the probability that the relation does not hold ************)
 (********** in ZK_R by the probability of returning true in the VFR game.  ************)
 
-local lemma ZKR_rel &m (H <: HOracle.Oracle {A, BPS, BP, BS, Ve, E, C, R})
-                       (S <: Simulator {E, C, P, Ve, A, R, BPS, BP, BS, H}) :
+local lemma ZKR_rel &m (H <: HOracle.Oracle { -A, -BPS, -BP, -BS, -Ve, -E, -C, -R })
+                       (S <: Simulator { -E, -C, -P, -Ve, -A, -R, -BPS, -BP, -BS, -H }) :
      islossless H.o
   => islossless S.o
   => islossless S.prove
@@ -1567,7 +1567,7 @@ local module G0R' (E  : Scheme)
 
 (******** Lemma proving that the above game is equivalent to security definition *******)
 
-local lemma DU_MB_BPRIV_R_G0'_R_equiv &m (H <: HOracle.Oracle {E, BP, G, A, C, Ve, S, R, P}) : 
+local lemma DU_MB_BPRIV_R_G0'_R_equiv &m (H <: HOracle.Oracle { -E, -BP, -G, -A, -C, -Ve, -S, -R, -P }) : 
   Pr[DU_MB_BPRIV_R(MV(E, P, Ve, C), A, H, G, S, Recover').main() @ &m : res]
   = Pr[G0R'(E, P, Ve, C, A, H, G, S).main() @ &m : res].
 proof.
@@ -1786,8 +1786,8 @@ local module G1R (E  : Scheme)
       var p1, b1, s1pr, s1po;
 
       if ((id \in BP.setH)) {
-        (s0pr, s0po, b0, p0)  <- vote_core(id, v0, oget BP.secmap.[id]);
-        (s1pr, s1po, b1, p1)  <- vote_core(id, v1, oget BP.secmap.[id]);
+        (s0pr, s0po, b0, p0)  <@ vote_core(id, v0, oget BP.secmap.[id]);
+        (s1pr, s1po, b1, p1)  <@ vote_core(id, v1, oget BP.secmap.[id]);
 
         BP.vmap.[id] <- (b0, b1, b0, v0) ::  (odflt [] BP.vmap.[id]);
         BP.bb0 <- (id, id, b0) :: BP.bb0;
@@ -2221,8 +2221,8 @@ local module G2R (E  : Scheme)
       var p1, b1, s1pr, s1po;
 
       if ((id \in BP.setH)) {
-        (s0pr, s0po, b0, p0)  <- vote_core(id, v0, oget BP.secmap.[id]);
-        (s1pr, s1po, b1, p1)  <- vote_core(id, v1, oget BP.secmap.[id]);
+        (s0pr, s0po, b0, p0)  <@ vote_core(id, v0, oget BP.secmap.[id]);
+        (s1pr, s1po, b1, p1)  <@ vote_core(id, v1, oget BP.secmap.[id]);
 
         (* We now store b1, b1, v0 instead of b0, b1, v0, as we did in G1R *)
         BP.vmap.[id] <- (b1, b1, b1, v0) :: (odflt [] BP.vmap.[id]);
@@ -2746,7 +2746,7 @@ local module G3R (E:Scheme, P:Prover, Ve:Verifier, C:ValidInd,
       var p1, b1, s1pr, s1po;
 
       if ((id \in BP.setH)) {
-        (s1pr, s1po, b1, p1)  <- vote_core(id, v1, oget BP.secmap.[id]);
+        (s1pr, s1po, b1, p1)  <@ vote_core(id, v1, oget BP.secmap.[id]);
 
         (* ballot cast, ballot counted, vote *)
         BP.vmap.[id] <- (b1, b1, s1po, v0) :: (odflt [] BP.vmap.[id]);

--- a/du_mb_bpriv/Selene/SeleneBpriv.ec
+++ b/du_mb_bpriv/Selene/SeleneBpriv.ec
@@ -416,9 +416,8 @@ declare axiom Ev_e_eq (ge: (glob Ev)):
    phoare[Ev(HRO.ERO).enc : (glob Ev) = ge ==> (glob Ev) = ge] = 1%r. 
 
 (*** Axioms linking key generation and get_epk operator ***)
-declare axiom Ev_kgen_get_epk (H <: HOracle.POracle):
- equiv [Ev(H).kgen ~ Ev(H).kgen : ={glob H, glob Ev} ==> ={glob H, glob Ev, res} /\ res{1}.`1 = get_epk res{1}.`2]. 
-
+declare axiom Ev_kgen_get_epk:
+ equiv [Ev(HRO.ERO).kgen ~ Ev(HRO.ERO).kgen : ={glob HRO.ERO, glob Ev} ==> ={glob HRO.ERO, glob Ev, res} /\ res{1}.`1 = get_epk res{1}.`2]. 
 
 (*** Sampling a list from list of all permutations doesn't fail ***)
 lemma duni_ap_weight (l : 'a list) : weight (duniform (allperms l)) = 1%r.  
@@ -1887,7 +1886,7 @@ inline*.
 wp;while(={BP.setidents, i0, pPk, pTr, pCo, pOp, tsk, tpk, trL, pi2}); first sim.
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim. 
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO).
+wp;rnd;call Ev_kgen_get_epk.
 auto;call(_:true). 
 while (={w, glob HRO.ERO}); first by sim.
 auto;progress. rewrite (H13 id1 c3 pc). apply H16. trivial. rewrite (in_rem_ids id1 pc c3) => />. 
@@ -2689,7 +2688,7 @@ wp;inline*.
  wp;while(={i0, BP.setidents, tpk, tsk, pPk, pTr, pCo, pOp, trL, pi2}); first sim.  
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim. 
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO);auto;call(_:true);
+wp;rnd;call Ev_kgen_get_epk;auto;call(_:true);
 while(={w, glob HRO.ERO}); first sim. 
 auto;progress. 
 
@@ -3041,7 +3040,7 @@ wp;inline*.
 wp;while(={i0, BP.setidents, tpk, tsk, pPk, pTr, pCo, pOp, trL, pi2}); first sim.  
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim. 
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO);wp;call(_:true). 
+wp;rnd;call Ev_kgen_get_epk;wp;call(_:true). 
 while(={w, HRO.ERO.m}); first sim. 
 auto;progress. smt(@List). smt(@SmtMap). smt(@SmtMap @List).
 
@@ -4653,7 +4652,7 @@ wp;inline*.
 wp;while(={i0, BP.setidents, tpk, tsk, pPk, pTr, pCo, pOp, trL, pi2}); first sim.  
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim.   
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO). wp;call(_:true). 
+wp;rnd;call Ev_kgen_get_epk. wp;call(_:true). 
 while(={w, HRO.ERO.m}); first sim. 
 auto;progress. 
 
@@ -5012,7 +5011,7 @@ if => //;auto;progress.
 wp;while(={BP.setidents, tpk, pPk, pTr, tsk, pCo, pOp, trL, pi2} /\ i0{1} = i{2});first sim. 
 wp;while(={glob CP, BP.setidents, tpk, trL, pTr, pPk} /\ i0{1} = i{2}); first sim. 
 wp;rnd;while(={BP.setidents, tpk, tpTr} /\ i0{1} = i{2}); first sim. 
-wp;rnd;wp;call(Ev_kgen_get_epk HRO.ERO). 
+wp;rnd;wp;call Ev_kgen_get_epk. 
 wp;call(_:true);while(={w, HRO.ERO.m});first sim. 
 auto;progress. smt(@List). smt(@SmtMap). rewrite (H11 i_R2). trivial. smt(@List).
 
@@ -5416,7 +5415,7 @@ if => //;auto;progress.
 wp;while(={BP.setidents, tpk, pPk, pTr, tsk, pCo, pOp, trL, pi2} /\ i0{1} = i{2}); first sim. 
 wp;while(={BP.setidents, tpk, trL, pTr, glob CP, pPk} /\ i0{1} = i{2}); first sim. 
 wp;rnd;while(={BP.setidents, tpk, tpTr, trL} /\ i0{1} = i{2}); first sim. 
-wp;rnd;wp;call(Ev_kgen_get_epk HRO.ERO). 
+wp;rnd;wp;call Ev_kgen_get_epk. 
 wp;call(_:true);while(={w, HRO.ERO.m});first sim. 
 auto;progress. smt(@List). smt(@SmtMap). rewrite (H11 i_R2); first trivial. smt(@List).
 

--- a/du_mb_bpriv/Selene/SeleneBpriv.ec
+++ b/du_mb_bpriv/Selene/SeleneBpriv.ec
@@ -3835,9 +3835,9 @@ while{1} (
 sp 1. if => //;wp. 
 skip;progress; first smt(size_ge0). smt(). 
 by rewrite cats1 size_rcons. 
-rewrite nth_cat. simplify.  
-have H14 : i1 < size bb'{hr} by smt(@List). rewrite H14.  simplify. 
-rewrite H3. exact H14. exact H13. trivial. 
+rewrite nth_cat. simplify.    
+case (i1 < size bb'{hr}) => i1_size. rewrite H3. done. exact H13. done. 
+case (i1 = size bb'{hr}) => i1_eq_size. have -> : i1 - size bb'{hr} = 0 by smt(). rewrite /=. smt(@List). smt(@List). 
 rewrite nth_cat.  simplify. 
 smt(@List).  
 rewrite nth_cat. 
@@ -3851,7 +3851,9 @@ move => H17. have H18 : (i1 - size bb'{hr} = 0) by smt(@List).
 rewrite H18. simplify. smt(@List). smt(). 
 auto;progress. smt(size_ge0). smt(). 
 by rewrite cats1 size_rcons. 
-smt(@List).  smt(@List). smt(@List). smt(@List). smt(). 
+rewrite nth_cat; 1: smt(@List).  
+rewrite nth_cat; 1: smt(@List). 
+smt(@List). smt(@List). smt(). 
 auto;progress. rewrite size_ge0. smt(@List). smt(). smt(). smt(@List). 
 auto;progress. smt(@List). 
  
@@ -4353,8 +4355,8 @@ sp 1. if => //;wp.
 skip;progress; first smt(size_ge0). smt(). 
 by rewrite cats1 size_rcons. 
 rewrite nth_cat. simplify.  
-have H14 : i1 < size bb'{hr} by smt(@List). 
-rewrite H14.  simplify. rewrite H3. exact H14. exact H13. trivial. 
+case (i1 < size bb'{hr}) => i1_size. rewrite H3. done. exact H13. done. 
+case (i1 = size bb'{hr}) => i1_eq_size. have -> : i1 - size bb'{hr} = 0 by smt(). rewrite /=. smt(@List). smt(@List). 
 rewrite nth_cat.  simplify. 
 smt(@List).  
 rewrite nth_cat. 
@@ -4367,7 +4369,10 @@ move => H17. have H18 : (i1 - size bb'{hr} = 0) by smt(@List).
 rewrite H18. simplify. smt(@List). smt(). 
 auto;progress. smt(size_ge0). smt(). 
 by rewrite cats1 size_rcons. 
-smt(@List).  smt(@List). smt(@List). smt(@List). smt(). 
+rewrite nth_cat; 1:smt(@List).
+rewrite nth_cat; 1:smt(@List). 
+rewrite nth_cat; 1:smt(@List). 
+rewrite nth_cat; 1:smt(@List). smt(). 
 auto;progress. rewrite size_ge0. smt(@List). smt(). smt(). smt(@List). 
 auto;progress. smt(@List). 
 
@@ -5145,9 +5150,27 @@ progress.
 wp;sp. 
 exists* (glob Ev), BS.sk{hr}, l, c3. elim* => gev sk l c3.  
 call (Edec_Odec_vo gev sk l c3).
-auto;progress. smt(). smt().    
-smt(@List @SmtMap). 
- smt(). smt(). smt(). smt(@List). smt(). 
+auto;progress. smt(). smt(). rewrite (take_nth witness i1{hr} cL0{hr});1: smt(). 
+rewrite -cats1 map_cat. 
+rewrite -H. 
+have -> : map
+  (fun (b1 : cipher * ident) =>
+     if ! ((b1.`1, b1.`2) \in BS.encL{hr}) 
+     then dec_cipher_vo BS.sk{hr} b1.`2 b1.`1 HRO.ERO.m{hr}
+     else None) 
+     [(c3{hr}, l{hr})] = [None] by smt(@List). 
+done. 
+ smt(). smt(). smt(). 
+
+rewrite (take_nth witness i1{hr} cL0{hr}); 1: done.  
+rewrite  -cats1 -H map_cat.
+have -> :  map (fun (b1 : cipher * ident) =>
+             if ! ((b1.`1, b1.`2) \in BS.encL{hr}) then
+             dec_cipher_vo BS.sk{hr} b1.`2 b1.`1 HRO.ERO.m{hr}
+             else None) [(c3{hr}, l{hr})] = 
+             [dec_cipher_vo BS.sk{hr} l{hr} c3{hr} HRO.ERO.m{hr}] by smt().
+done. smt().  
+ 
 auto;progress. rewrite size_ge0. rewrite take0.  smt(). smt(). 
 have -> : (take i1_R
      (map
@@ -5163,7 +5186,7 @@ have ? : forall id c, !( (c,id) \in BS.encL{2})
       => !( (id, oget BP.pubmap{2}.[id], c) \in BCCA.bb{2}) by smt(). 
 have ? : i1_R = size (map
         (fun (x : (ident * upkey * commitment) * cipher) => (x.`2, x.`1.`1))
-        BP.bb{2}). smt(). apply eq_map. progress. smt.
+        BP.bb{2}). smt(). apply eq_map. progress. smt().
 qed. 
 
 
@@ -5465,7 +5488,7 @@ while(={j, BP.bb, rL,  glob HRO.ERO, BP.pk, BP.vmap, BP.pubmap} /\ 0 <= j{2}
 sp 3 3. 
 wp 1 1. 
   
-if{1} => //. if{2} => //.  
+if{1} => //. if{2} => //.   
 auto;progress => /#.  
 auto;progress => /#.
  
@@ -5509,8 +5532,12 @@ wp;sp.
 exists* (glob Ev), BS.sk{hr}, l, c3. elim* => gev sk l c3.  
  call (Edec_Odec_vo gev sk l c3).
 auto;progress. smt(). smt().    
-smt(@List @SmtMap). 
- smt(). smt(). smt(). smt(@List). smt(). 
+rewrite (take_nth witness i1{hr} cL0{hr}); 1:done. 
+rewrite -cats1 -H map_cat; 1:smt(@List).  
+smt(). smt(). smt(). 
+rewrite (take_nth witness i1{hr} cL0{hr}); 1:done. 
+rewrite -cats1 -H map_cat; 1:smt(@List). 
+smt(). 
 auto;progress. rewrite size_ge0. 
 rewrite take0. smt(). 
 smt(). 
@@ -5532,7 +5559,7 @@ have ? : i1_R = size (map
 qed. 
 
 
-(**** Some useful lemmas for the final SMT call ****)
+(**** Some useful lemmas for the final lemma ****)
 local lemma G2L_G3R_cca &m : 
     BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
     `| Pr[G2L(Ev,Ve,C,CP,A,HRO.ERO,S).main() @ &m : res] - 
@@ -5563,15 +5590,6 @@ proof.
 move => id_union. 
 by rewrite (DU_MB_BPRIV_L_G0L'_equiv &m id_union) (G0L'_G0L_equiv &m id_union). 
 qed. 
-
-local lemma G1L_IND1CCA_L_equiv &m :
-    BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
-    Pr[G1L(Ev,Ve,C,CP,A,HRO.ERO,S).main() @ &m : res] = 
-    Pr[Ind1CCA(Ev,BCCA(Selene(Ev,P,Ve,C,CP),CP,A,S),HRO.ERO,Left).main() @ &m : res]. 
-proof. 
-move => id_union. 
-by rewrite (G1L_G2L_equiv &m id_union) (G2L_CCA_left_equiv &m id_union). 
-qed. 
  
 lemma du_mb_bpriv &m : 
   BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
@@ -5585,7 +5603,7 @@ lemma du_mb_bpriv &m :
     + `| Pr[Ind1CCA(Ev,BCCA(Selene(Ev,P,Ve,C,CP),CP,A,S),HRO.ERO,Left).main() @ &m : res] 
          - Pr[Ind1CCA(Ev,BCCA(Selene(Ev,P,Ve,C,CP),CP,A,S),HRO.ERO,Right).main() @ &m : res]|. 
 proof. 
-move => id_union. 
+move => id_union.  
 
 (** Add and subtract G1L to the first absolute value **)
 have -> : 
@@ -5597,18 +5615,31 @@ have -> :
     - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
   by smt().  
  
-(** Triangle inequality **)
-have triang : 
-  `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP), A, HRO.ERO, G).main() @ &m : res] 
-  - Pr[G1L(Ev,Ve,C,CP,A,HRO.ERO,S).main() @ &m : res]
-  + Pr[G1L(Ev,Ve,C,CP,A,HRO.ERO,S).main() @ &m : res]
-  - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
-  <= `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP), A, HRO.ERO, G).main() @ &m : res]
-     - Pr[G1L(Ev,Ve,C,CP,A,HRO.ERO,S).main() @ &m : res]| 
-   + `|Pr[G1L(Ev,Ve,C,CP,A,HRO.ERO,S).main() @ &m : res] 
-     - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP), A, HRO.ERO, G, S, Recover').main () @ &m : res]|
-  by smt(@Real). 
-by smt. 
-qed. 
+rewrite (DU_MB_BPRIV_L_G0L'_equiv &m); 1:done.
+rewrite (G0L'_G0L_equiv &m); 1:done.  
+
+have H0 : `|Pr[G0L(Ev, P, Ve, C, CP, A, HRO.ERO, G).main() @ &m : res] -
+            Pr[G1L(Ev, Ve, C, CP, A, HRO.ERO, S).main() @ &m : res]| +
+          `|Pr[G1L(Ev, Ve, C, CP, A, HRO.ERO, S).main() @ &m : res] -
+            Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP), A, HRO.ERO, G, S, Recover').main() @ &m : res]| <=
+            Pr[VFRS(Ev, BVFR(Selene(Ev, P, Ve, C, CP), A, CP), R, CP, HRO.ERO, G).main() @ &m : res] +
+            Pr[VFRS(Ev, BVFR(Selene(Ev, P, Ve, C, CP), A, CP), R, CP, HRO.ERO, S).main() @ &m : res] +
+          `|Pr[ZK_L(R(Ev, HRO.ERO), P, BZK(Ev, P, C, Ve, A, CP, HRO.ERO), G).main() @ &m : res] -
+            Pr[ZK_R(R(Ev, HRO.ERO), S, BZK(Ev, P, C, Ve, A, CP, HRO.ERO)).main() @ &m : res]| +
+          `|Pr[Ind1CCA(Ev, BCCA(Selene(Ev, P, Ve, C, CP), CP, A, S), HRO.ERO, Left).main() @ &m : res] -
+            Pr[Ind1CCA(Ev, BCCA(Selene(Ev, P, Ve, C, CP), CP, A, S), HRO.ERO, Right).main() @ &m : res]|. 
+
+rewrite (DU_MB_BPRIV_R_G3R_equiv &m); 1:done. 
+
+have -> : `|Pr[G1L(Ev, Ve, C, CP, A, HRO.ERO, S).main() @ &m : res] -
+            Pr[G3R(Ev, Ve, C, CP, A, HRO.ERO, S).main() @ &m : res]| = 
+          `|Pr[G2L(Ev, Ve, C, CP, A, HRO.ERO, S).main() @ &m : res] -
+            Pr[G3R(Ev, Ve, C, CP, A, HRO.ERO, S).main() @ &m : res]|
+  by rewrite (G1L_G2L_equiv &m). 
+
+rewrite (G2L_G3R_cca &m); 1:done.
+smt(G0L_G1L_zk_vfr).  
+smt(). 
+qed.  
 
 end section DU_MB_BPRIV. 

--- a/du_mb_bpriv/Selene/SeleneBpriv.ec
+++ b/du_mb_bpriv/Selene/SeleneBpriv.ec
@@ -334,15 +334,15 @@ module BCCA(V:VotingSystem, CP:CommitmentProtocol, A:DU_MB_BPRIV_adv, S:Simulato
 
 section DU_MB_BPRIV.
 
-declare module G  <: GOracle.Oracle { BP, HRO.ERO, BPS, BS, BCCA }.   
-declare module Ev <: PKEvo.Scheme { BP, HRO.ERO, G, BPS, BS, BCCA}.  
-declare module S  <: Simulator { BP, HRO.ERO, G, Ev, BPS, BS, BCCA }. 
-declare module Ve <: Verifier { BP, HRO.ERO, G, Ev, S, BPS, BS, BCCA }. 
-declare module P  <: Prover { BP, HRO.ERO, G, Ev, S, Ve, BPS, BS, BCCA }. 
-declare module R  <: VotingRelationS { BP, HRO.ERO, G, Ev, S, Ve, P, BPS, BS, BCCA }.
-declare module C  <: ValidIndS { BP, HRO.ERO, G, Ev, S, Ve, P, BPS, BS, R, BCCA }. 
-declare module A  <: DU_MB_BPRIV_adv { BP, HRO.ERO, G, Ev, S, Ve, P, C, BPS, BS, R, BCCA}. 
-declare module CP <: CommitmentProtocol { BP, HRO.ERO, G, Ev, S, Ve, P, C, BPS, BS, A, R, BCCA}. 
+declare module G  <: GOracle.Oracle { -BP, -HRO.ERO, -BPS, -BS, -BCCA }.   
+declare module Ev <: PKEvo.Scheme { -BP, -HRO.ERO, -G, -BPS, -BS, -BCCA}.  
+declare module S  <: Simulator { -BP, -HRO.ERO, -G, -Ev, -BPS, -BS, -BCCA }. 
+declare module Ve <: Verifier { -BP, -HRO.ERO, -G, -Ev, -S, -BPS, -BS, -BCCA }. 
+declare module P  <: Prover { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -BPS, -BS, -BCCA }. 
+declare module R  <: VotingRelationS { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -BPS, -BS, -BCCA }.
+declare module C  <: ValidIndS { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -BPS, -BS, -R, -BCCA }. 
+declare module A  <: DU_MB_BPRIV_adv { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -C, -BPS, -BS, -R, -BCCA}. 
+declare module CP <: CommitmentProtocol { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -C, -BPS, -BS, -A, -R, -BCCA}. 
 
 (*** Lossless assumptions ***)
 
@@ -352,25 +352,25 @@ declare axiom Go_ll : islossless G.o.
 
 
 (** MB-BPRIV adversary **)
-declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { A }):
+declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { -A }):
   islossless O.vote => islossless O.board => islossless O.h => islossless O.g => islossless A(O).create_bb. 
-declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.board => islossless O.h => islossless O.g => islossless A(O).get_tally. 
-declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.verify => islossless O.h => islossless O.g => islossless A(O).final_guess. 
-declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.h => islossless O.g => islossless A(O).initial_guess. 
 
 
 (** Proof system **)
-declare axiom PS_p_ll (G <: GOracle.POracle) : islossless G.o => islossless P(G).prove. 
-declare axiom PS_v_ll (G <: GOracle.POracle) : islossless G.o => islossless Ve(G).verify. 
+declare axiom PS_p_ll (G <: GOracle.POracle { -P }) : islossless G.o => islossless P(G).prove. 
+declare axiom PS_v_ll (G <: GOracle.POracle { -Ve }) : islossless G.o => islossless Ve(G).verify. 
 
 
 (** Encryption **)
-declare axiom Ev_kg_ll  (H <: HOracle.POracle) : islossless H.o => islossless Ev(H).kgen. 
-declare axiom Ev_enc_ll (H <: HOracle.POracle) : islossless H.o => islossless Ev(H).enc. 
-declare axiom Ev_dec_ll (H <: HOracle.POracle) : islossless H.o => islossless Ev(H).dec. 
+declare axiom Ev_kg_ll  (H <: HOracle.POracle { -Ev }) : islossless H.o => islossless Ev(H).kgen. 
+declare axiom Ev_enc_ll (H <: HOracle.POracle { -Ev }) : islossless H.o => islossless Ev(H).enc. 
+declare axiom Ev_dec_ll (H <: HOracle.POracle { -Ev }) : islossless H.o => islossless Ev(H).dec. 
  
 lemma Et_kg_ll  : islossless ElGamal.kg. 
 proof. 
@@ -405,7 +405,7 @@ declare axiom CP_open_ll : islossless CP.open.
 declare axiom R_m_ll : islossless R(Ev,HRO.ERO).main.
 
 (** ValidInd operator **)
-declare axiom C_vi_ll (H <: HOracle.POracle) : islossless H.o => islossless C(H).valid.
+declare axiom C_vi_ll (H <: HOracle.POracle { -C }) : islossless H.o => islossless C(H).valid.
 
 (*** Useful and necessary axioms and lemmas ***)
 local equiv So_ll2: S.o ~ S.o : ={arg, glob S} ==> ={res, glob S}.
@@ -505,8 +505,8 @@ op rem_fst4 (x : ('a * 'b * 'c * 'd)) = (x.`2, x.`3, x.`4).
 module type VotingAdvZK (H:HOracle.Oracle, O:GOracle.POracle) = {
   proc a1() : ((epkey * pkey * aux) * ((ident * upkey * commitment) *
                   cipher) list * (vote list * tracker list)) * (((ident,opening) fmap * eskey * PKEtr.skey) *
-                  ((ident * upkey * commitment) * cipher) list) {H.init H.o O.o}
-  proc a2(pi : (prf option)) : bool {H.o O.o}
+                  ((ident * upkey * commitment) * cipher) list) {H.init, H.o, O.o}
+  proc a2(pi : (prf option)) : bool {H.o, O.o}
 }.
 
 module BZK(Ev:PKEvo.Scheme, P:Prover, C:ValidIndS, Ve:Verifier, 
@@ -609,7 +609,7 @@ module BZK(Ev:PKEvo.Scheme, P:Prover, C:ValidIndS, Ve:Verifier,
 }. 
 
 (******* Losslessness for BZK ********)
-local lemma BZK_a1_ll (H <: HOracle.Oracle {BP, A}) (G <: GOracle.POracle {A}) : 
+local lemma BZK_a1_ll (H <: HOracle.Oracle { -BP, -A}) (G <: GOracle.POracle { -A }) : 
     islossless H.init => islossless H.o => islossless G.o =>
     islossless BZK(Ev,P,C,Ve,A,CP,H,G).a1. 
 proof. 
@@ -639,7 +639,7 @@ smt(@FSet). smt(). rewrite size_ge0. smt().
 by rewrite duni_ap_weight.  
 qed. 
 
-local lemma BZK_a2_ll (H <: HOracle.Oracle {A, BP}) (G <: GOracle.POracle {A, BP}) :
+local lemma BZK_a2_ll (H <: HOracle.Oracle { -A, -BP }) (G <: GOracle.POracle { -A, -BP }) :
   islossless H.o => islossless G.o => islossless BZK(Ev,P,C,Ve,A,CP,H,G).a2. 
 proof. 
 move => Ho_ll Go_ll. 
@@ -670,8 +670,8 @@ if => //. rnd;skip;progress. rewrite dboolE => />.
 hoare;call(_:true); [1..3: by auto]; first trivial.
 qed. 
 
-local lemma BZK_a2_ll' (H <: HOracle.Oracle {A, BP}) (G <: GOracle.POracle {A, BP})
-                        (P <: Prover {Ev,C,Ve,A,ZK_L,BPS,BP,H,G}) :
+local lemma BZK_a2_ll' (H <: HOracle.Oracle { -A, -BP }) (G <: GOracle.POracle { -A, -BP })
+                        (P <: Prover { -Ev, -C, -Ve, -A, -ZK_L, -BPS, -BP, -H, -G }) :
   islossless H.o => islossless G.o => islossless P(G).prove => islossless BZK(Ev,P,C,Ve,A,CP,H,G).a2. 
 proof. 
 move => Ho_ll Go_ll Pp_ll. 
@@ -1302,9 +1302,9 @@ qed.
 (*************** Lemma bounding the probability that the relation does not hold in ZK_L by ***************)
 (***************     the probability of returning true in the VFR game.                    ***************)
 
-local lemma ZKL_rel &m (H <: HOracle.Oracle {A, BPS, BP, BS, Ve, Ev, C, R, CP})
-                       (G <: GOracle.Oracle {A, BPS, BP, BS, Ve, Ev, H, R, C, CP})
-                       (P <: Prover {Ev, C, Ve, A, R, BPS, BP, BS, H, G, CP}) :
+local lemma ZKL_rel &m (H <: HOracle.Oracle { -A,  -BPS,  -BP,  -BS,  -Ve,  -Ev, -C, -R, -CP })
+                       (G <: GOracle.Oracle { -A,  -BPS,  -BP,  -BS,  -Ve,  -Ev, -C, -R, -CP, -H })
+                       (P <: Prover { -Ev,  -C,  -Ve,  -A,  -R,  -BPS,  -BP,  -BS,  -H,  -G,  -CP}) :
   BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
   islossless H.o => islossless G.o => islossless P(G).prove =>
     Pr[ZK_L(R(Ev,H), P, BZK(Ev,P,C,Ve,A,CP,H), G).main() @ &m : !BPS.rel]
@@ -1363,8 +1363,8 @@ qed.
 (*************** Lemma bounding the probability that the relation does not hold in ZK_R by ***************)
 (***************     the probability of returning true in the VFR game.                    ***************)
 
-local lemma ZKR_rel &m (H <: HOracle.Oracle {A, BPS, BP, BS, Ve, Ev, C, CP, R})
-                       (S <: Simulator {Ev, C, CP, Ve, A, R, BPS, BP, BS, H}) :
+local lemma ZKR_rel &m (H <: HOracle.Oracle { -A, -BPS, -BP, -BS, -Ve, -Ev, -C, -CP, -R})
+                       (S <: Simulator { -Ev, -C, -CP, -Ve, -A, -R, -BPS, -BP, -BS, -H}) :
      BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
      islossless H.o => islossless S.o => islossless S.prove =>
      Pr[ZK_R(R(Ev,H), S, BZK(Ev,P,C,Ve,A,CP,H)).main() @ &m : !BPS.rel] <=

--- a/du_mb_bpriv/Selene/SeleneStrongConsistency.ec
+++ b/du_mb_bpriv/Selene/SeleneStrongConsistency.ec
@@ -253,16 +253,16 @@ module SConsis3_R(V:VotingSystem, Ex:Extractor, C:ValidIndS,
 
 section StrongConsistency.
 
-declare module H  <: HOracle.Oracle { BP }. 
-declare module G  <: GOracle.Oracle { BP, H, HRO.ERO }. 
-declare module Ev <: PKEvo.Scheme { BP, H, G, HRO.ERO }.  
-declare module C  <: ValidIndS { BP, H, G, Ev, HRO.ERO }. 
-declare module P  <: Prover { BP, H, G, Ev, C }. 
-declare module Ve <: Verifier { BP, H, G, Ev, C, P }.
-declare module CP <: CommitmentProtocol { BP, H, G, Ev, C, P, Ve, HRO.ERO }.
+declare module H  <: HOracle.Oracle { -BP }. 
+declare module G  <: GOracle.Oracle { -BP, -H, -HRO.ERO }. 
+declare module Ev <: PKEvo.Scheme { -BP, -H, -G, -HRO.ERO }.  
+declare module C  <: ValidIndS { -BP, -H, -G, -Ev, -HRO.ERO }. 
+declare module P  <: Prover { -BP, -H, -G, -Ev, -C }. 
+declare module Ve <: Verifier { -BP, -H, -G, -Ev, -C, -P }.
+declare module CP <: CommitmentProtocol { -BP, -H, -G, -Ev, -C, -P, -Ve, -HRO.ERO }.
 
-declare module Asc2 <: SConsis2_adv { BP, H, G, Ev, C, P, Ve, CP, HRO.ERO }. 
-declare module Asc3 <: SConsis3_adv { BP, H, G, Ev, C, P, Ve, CP }.  
+declare module Asc2 <: SConsis2_adv { -BP, -H, -G, -Ev, -C, -P, -Ve, -CP, -HRO.ERO }. 
+declare module Asc3 <: SConsis3_adv { -BP, -H, -G, -Ev, -C, -P, -Ve, -CP }.  
 
 (* validInd operator *)
 op validInd : epkey -> ((ident * upkey * commitment) * cipher) -> (h_in, h_out) fmap -> bool.
@@ -310,15 +310,15 @@ declare axiom Ev_kgen_ll' : islossless Ev(HRO.ERO).kgen.
 declare axiom CP_gen_ll : islossless CP.gen. 
 
 (* proof system *)
-declare axiom PS_p_ll (G <: GOracle.POracle) : 
+declare axiom PS_p_ll (G <: GOracle.POracle { -P }) : 
     islossless G.o => islossless P(G).prove.  
 
 (* SConis2 adversary *)
-declare axiom Asc2_ll (O <: SCons_Oracle {Asc2}) : 
+declare axiom Asc2_ll (O <: SCons_Oracle { -Asc2 }) : 
   islossless H.o => islossless G.o => islossless Asc2(O).main. 
 
 (* SConsis3 adversary *)
-declare axiom Asc3_ll (O <: SCons_Oracle {Asc3}) : 
+declare axiom Asc3_ll (O <: SCons_Oracle { -Asc3 }) : 
   islossless H.o => islossless G.o => islossless Asc3(O).main. 
 
 (* Concrete extractor taking a ballot (pc, c) and secret data BP.sk *)

--- a/du_mb_bpriv/Selene_with_signatures/SeleneBpriv_sign.ec
+++ b/du_mb_bpriv/Selene_with_signatures/SeleneBpriv_sign.ec
@@ -289,7 +289,7 @@ module BCCA(V:VotingSystem, SS: SignatureScheme, CP:CommitmentProtocol,
                      => (x.`2, x.`1.`1)) BP.bb;
       
       (* decrypt everything in BP.bb *)
-      mL <- IO.dec(cL);
+      mL <@ IO.dec(cL);
 
       j <- 0;
       rL <- [];
@@ -349,16 +349,16 @@ module BCCA(V:VotingSystem, SS: SignatureScheme, CP:CommitmentProtocol,
 
 section DU_MB_BPRIV.
 
-declare module G  <: GOracle.Oracle { BP, HRO.ERO, BPS, BS, BCCA }.   
-declare module Ev <: PKEvo.Scheme { BP, HRO.ERO, G, BPS, BS, BCCA}.  
-declare module S  <: Simulator { BP, HRO.ERO, G, Ev, BPS, BS, BCCA }. 
-declare module Ve <: Verifier { BP, HRO.ERO, G, Ev, S, BPS, BS, BCCA }. 
-declare module P  <: Prover { BP, HRO.ERO, G, Ev, S, Ve, BPS, BS, BCCA }. 
-declare module R  <: VotingRelationS { BP, HRO.ERO, G, Ev, S, Ve, P, BPS, BS, BCCA }.
-declare module C  <: ValidIndS { BP, HRO.ERO, G, Ev, S, Ve, P, BPS, BS, R, BCCA }. 
-declare module A  <: DU_MB_BPRIV_adv { BP, HRO.ERO, G, Ev, S, Ve, P, C, BPS, BS, R, BCCA}. 
-declare module CP <: CommitmentProtocol { BP, HRO.ERO, G, Ev, S, Ve, P, C, BPS, BS, A, R, BCCA}. 
-declare module SS <: SignatureScheme { BP,HRO.ERO,G,Ev,S,Ve,P,C,BPS,BS,A,R,BCCA, CP}. 
+declare module G  <: GOracle.Oracle { -BP, -HRO.ERO, -BPS, -BS, -BCCA }.   
+declare module Ev <: PKEvo.Scheme { -BP, -HRO.ERO, -G, -BPS, -BS, -BCCA}.  
+declare module S  <: Simulator { -BP, -HRO.ERO, -G, -Ev, -BPS, -BS, -BCCA }. 
+declare module Ve <: Verifier { -BP, -HRO.ERO, -G, -Ev, -S, -BPS, -BS, -BCCA }. 
+declare module P  <: Prover { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -BPS, -BS, -BCCA }. 
+declare module R  <: VotingRelationS { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -BPS, -BS, -BCCA }.
+declare module C  <: ValidIndS { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -BPS, -BS, -R, -BCCA }. 
+declare module A  <: DU_MB_BPRIV_adv { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -C, -BPS, -BS, -R, -BCCA}. 
+declare module CP <: CommitmentProtocol { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -C, -BPS, -BS, -A, -R, -BCCA}. 
+declare module SS <: SignatureScheme { -BP, -HRO.ERO, -G, -Ev, -S, -Ve, -P, -C, -BPS, -BS, -A, -R, -BCCA, -CP}. 
 
 (*** Lossless assumptions ***)
 
@@ -367,26 +367,26 @@ declare axiom Gi_ll : islossless G.init.
 declare axiom Go_ll : islossless G.o. 
 
 (** MB-BPRIV adversary **)
-declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { A }):
+declare axiom A_a1_ll (O <: DU_MB_BPRIV_oracles { -A }):
   islossless O.vote => islossless O.board => islossless O.h 
                     => islossless O.g => islossless A(O).create_bb. 
-declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a2_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.board => islossless O.h => islossless O.g => islossless A(O).get_tally. 
-declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a3_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.verify => islossless O.h => islossless O.g => islossless A(O).final_guess. 
-declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { A }): 
+declare axiom A_a4_ll (O <: DU_MB_BPRIV_oracles { -A }): 
   islossless O.h => islossless O.g => islossless A(O).initial_guess. 
 
 
 (** Proof system **)
-declare axiom PS_p_ll (G <: GOracle.POracle) : islossless G.o => islossless P(G).prove. 
-declare axiom PS_v_ll (G <: GOracle.POracle) : islossless G.o => islossless Ve(G).verify. 
+declare axiom PS_p_ll (G <: GOracle.POracle { -P })  : islossless G.o => islossless P(G).prove. 
+declare axiom PS_v_ll (G <: GOracle.POracle { -Ve }) : islossless G.o => islossless Ve(G).verify. 
 
 
 (** Encryption **)
-declare axiom Ev_kg_ll  (H <: HOracle.POracle) : islossless H.o => islossless Ev(H).kgen. 
-declare axiom Ev_enc_ll (H <: HOracle.POracle) : islossless H.o => islossless Ev(H).enc. 
-declare axiom Ev_dec_ll (H <: HOracle.POracle) : islossless H.o => islossless Ev(H).dec. 
+declare axiom Ev_kg_ll  (H <: HOracle.POracle { -Ev }) : islossless H.o => islossless Ev(H).kgen. 
+declare axiom Ev_enc_ll (H <: HOracle.POracle { -Ev }) : islossless H.o => islossless Ev(H).enc. 
+declare axiom Ev_dec_ll (H <: HOracle.POracle { -Ev }) : islossless H.o => islossless Ev(H).dec. 
  
 lemma Et_kg_ll  : islossless ElGamal.kg. 
 proof. 
@@ -426,7 +426,7 @@ declare axiom SS_verify_ll : islossless SS.verify.
 declare axiom R_m_ll : islossless R(Ev,HRO.ERO).main.
 
 (** ValidInd operator **)
-declare axiom C_vi_ll (H <: HOracle.POracle) : islossless H.o => islossless C(H).valid.
+declare axiom C_vi_ll (H <: HOracle.POracle { -C }) : islossless H.o => islossless C(H).valid.
 
 (*** Useful and necessary axioms and lemmas ***)
 local equiv So_ll2: S.o ~ S.o : ={arg, glob S} ==> ={res, glob S}.
@@ -437,9 +437,9 @@ declare axiom Ev_e_eq (ge: (glob Ev)):
    phoare[Ev(HRO.ERO).enc : (glob Ev) = ge ==> (glob Ev) = ge] = 1%r. 
 
 (*** Axioms linking key generation and get_epk operator ***)
-declare axiom Ev_kgen_get_epk (H <: HOracle.POracle):
- equiv [Ev(H).kgen ~ Ev(H).kgen : ={glob H, glob Ev} ==> 
-       ={glob H, glob Ev, res} /\ res{1}.`1 = get_epk res{1}.`2]. 
+declare axiom Ev_kgen_get_epk:
+ equiv [Ev(HRO.ERO).kgen ~ Ev(HRO.ERO).kgen : ={glob HRO.ERO, glob Ev} ==> 
+       ={glob HRO.ERO, glob Ev, res} /\ res{1}.`1 = get_epk res{1}.`2]. 
 
 (* signing does not change state of signature scheme *)
 declare axiom SS_s_eq (ge: (glob SS)):
@@ -473,10 +473,11 @@ rewrite /rem_ids.
 rewrite mapP. exists (id, pc, c, s). apply in_bb. 
 qed. 
 
-(**** Decryption operator ****)
+(**** Decryption operator for votes ****)
 declare op dec_cipher_vo: eskey -> ident -> cipher  -> 
               (h_in, h_out) SmtMap.fmap -> vote option.
 
+(**** Decryption operator for trackers ****)
 declare op dec_cipher_tr: eskey -> cipher  -> tracker option.
 
 declare axiom Eenc_dec_vo (sk2: eskey) (pk2: epkey) (l2: ident) (p2: vote): 
@@ -538,8 +539,8 @@ module type VotingAdvZK (H:HOracle.Oracle, O:GOracle.POracle) = {
                (vote list * tracker list)) * 
               (((ident,opening) fmap * eskey * PKEtr.skey) *
                ((ident * upkey * supkey * commitment) * cipher*signature) list) 
-                   {H.init H.o O.o}
-  proc a2(pi : (prf option)) : bool {H.o O.o}
+                   {H.init, H.o, O.o}
+  proc a2(pi : (prf option)) : bool {H.o, O.o}
 }.
 
 module (BZK(Ev:PKEvo.Scheme, P:Prover, C:ValidIndS, Ve:Verifier, 
@@ -646,7 +647,7 @@ module (BZK(Ev:PKEvo.Scheme, P:Prover, C:ValidIndS, Ve:Verifier,
 }. 
 
 (******* Losslessness for BZK ********)
-local lemma BZK_a1_ll (H <: HOracle.Oracle {BP, A}) (G <: GOracle.POracle {A}) : 
+local lemma BZK_a1_ll (H <: HOracle.Oracle {-BP, -A}) (G <: GOracle.POracle {-A}) : 
     islossless H.init => islossless H.o => islossless G.o =>
     islossless BZK(Ev,P,C,Ve,A,CP,SS,H,G).a1. 
 proof. 
@@ -678,7 +679,7 @@ smt(@FSet). smt(). rewrite size_ge0. smt().
 by rewrite duni_ap_weight.  
 qed. 
 
-local lemma BZK_a2_ll (H <: HOracle.Oracle {A, BP}) (G <: GOracle.POracle {A, BP}) :
+local lemma BZK_a2_ll (H <: HOracle.Oracle {-A, -BP}) (G <: GOracle.POracle {-A, -BP}) :
   islossless H.o => islossless G.o => islossless BZK(Ev,P,C,Ve,A,CP,SS,H,G).a2. 
 proof. 
 move => Ho_ll Go_ll. 
@@ -709,8 +710,8 @@ if => //. rnd;skip;progress. rewrite dboolE => />.
 hoare;call(_:true); [1..3: by auto]; first trivial.
 qed. 
 
-local lemma BZK_a2_ll' (H <: HOracle.Oracle {A, BP}) (G <: GOracle.POracle {A, BP})
-                        (P <: Prover {Ev,C,Ve,A,ZK_L,BPS,BP,H,G}) :
+local lemma BZK_a2_ll' (H <: HOracle.Oracle {-A, -BP}) (G <: GOracle.POracle {-A, -BP})
+                        (P <: Prover {-Ev, -C, -Ve, -A, -ZK_L, -BPS, -BP, -H, -G}) :
   islossless H.o => islossless G.o => islossless P(G).prove 
                  => islossless BZK(Ev,P,C,Ve,A,CP,SS,H,G).a2. 
 proof. 
@@ -1371,9 +1372,9 @@ qed.
 (************* Lemma bounding the probability that the relation does not hold in ZK_L by *************)
 (*************     the probability of returning true in the VFR game.                    *************)
 
-local lemma ZKL_rel &m (H <: HOracle.Oracle {A, BPS, BP, BS, Ve, Ev, C, R, CP, SS})
-                       (G <: GOracle.Oracle {A, BPS, BP, BS, Ve, Ev, H, R, C, CP, SS})
-                       (P <: Prover {Ev, C, Ve, A, R, BPS, BP, BS, H, G, CP, SS}) :
+local lemma ZKL_rel &m (H <: HOracle.Oracle {-A, -BPS, -BP, -BS, -Ve, -Ev, -C, -R, -CP, -SS})
+                       (G <: GOracle.Oracle {-A, -BPS, -BP, -BS, -Ve, -Ev, -H, -R, -C, -CP, -SS})
+                       (P <: Prover {-Ev, -C, -Ve, -A, -R, -BPS, -BP, -BS, -H, -G, -CP, -SS}) :
   BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
   islossless H.o => islossless G.o => islossless P(G).prove =>
     Pr[ZK_L(R(Ev,H), P, BZK(Ev,P,C,Ve,A,CP,SS,H), G).main() @ &m : !BPS.rel]
@@ -1434,8 +1435,8 @@ qed.
 (************* Lemma bounding the probability that the relation does not hold in ZK_R by *************)
 (*************     the probability of returning true in the VFR game.                    *************)
 
-local lemma ZKR_rel &m (H <: HOracle.Oracle {A, BPS, BP, BS, Ve, Ev, C, CP, SS, R})
-                       (S <: Simulator {Ev, C, CP, SS, Ve, A, R, BPS, BP, BS, H}) :
+local lemma ZKR_rel &m (H <: HOracle.Oracle {-A, -BPS, -BP, -BS, -Ve, -Ev, -C, -CP, -SS, -R})
+                       (S <: Simulator {-Ev, -C, -CP, -SS, -Ve, -A, -R, -BPS, -BP, -BS, -H}) :
      BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
      islossless H.o => islossless S.o => islossless S.prove =>
      Pr[ZK_R(R(Ev,H), S, BZK(Ev,P,C,Ve,A,CP,SS,H)).main() @ &m : !BPS.rel] <=
@@ -1959,7 +1960,7 @@ inline*.
 wp;while(={BP.setidents, i0, pPk, pTr, pCo, pOp, tsk, tpk, trL, pi2}); first sim.
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim. 
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO).
+wp;rnd;call(Ev_kgen_get_epk).
 auto;call(_:true). 
 while (={w, glob HRO.ERO}); first by sim.
 auto;progress. rewrite (H13 id1 c3 s0 pc). apply H16. 
@@ -2747,7 +2748,7 @@ wp;inline*.
  wp;while(={i0, BP.setidents, tpk, tsk, pPk, pTr, pCo, pOp, trL, pi2}); first sim.  
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim. 
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO);auto;call(_:true);
+wp;rnd;call(Ev_kgen_get_epk);auto;call(_:true);
 while(={w, glob HRO.ERO}); first sim. 
 auto;progress. 
 
@@ -2853,7 +2854,8 @@ call{1} (Edec_Odec_vo gev sk.`2 id ev). auto;progress.
 
 move: H6; rewrite mapP /drop_last_of4 //=; elim => x [Hxm [Hx1 [Hx2 Hx3]]].
 have Ho:= H2 x.`1 x.`3 x.`4 _; first by smt().
-smt(@List @SmtMap). 
+
+smt(@List @SmtMap).
 
 call(_: ={glob HRO.ERO}).  sim. auto;progress. 
 
@@ -3086,7 +3088,7 @@ wp;inline*.
 wp;while(={i0, BP.setidents, tpk, tsk, pPk, pTr, pCo, pOp, trL, pi2}); first sim.  
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim. 
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO);wp;call(_:true). 
+wp;rnd;call(Ev_kgen_get_epk);wp;call(_:true). 
 while(={w, HRO.ERO.m}); first sim. 
 auto;progress. smt(@List). smt(@SmtMap). smt(@SmtMap @List).
 
@@ -4637,7 +4639,7 @@ wp;inline*.
 wp;while(={i0, BP.setidents, tpk, tsk, pPk, pTr, pCo, pOp, trL, pi2}); first sim.  
 wp;while(={i0, BP.setidents, trL, pTr, glob CP, pPk, tpk}); first sim. 
 wp;rnd;while(={i0, BP.setidents, tpk, tpTr, trL}); first sim.   
-wp;rnd;call(Ev_kgen_get_epk HRO.ERO). wp;call(_:true). 
+wp;rnd;call(Ev_kgen_get_epk). wp;call(_:true). 
 while(={w, HRO.ERO.m}); first sim. 
 by auto;progress. 
 
@@ -4937,7 +4939,7 @@ if => //;auto;progress.
 wp;while(={BP.setidents, tpk, pPk, pTr, tsk, pCo, pOp, trL, pi2} /\ i0{1} = i{2});first sim. 
 wp;while(={glob CP, BP.setidents, tpk, trL, pTr, pPk} /\ i0{1} = i{2}); first sim. 
 wp;rnd;while(={BP.setidents, tpk, tpTr} /\ i0{1} = i{2}); first sim. 
-wp;rnd;wp;call(Ev_kgen_get_epk HRO.ERO). 
+wp;rnd;wp;call(Ev_kgen_get_epk). 
 wp;call(_:true);while(={w, HRO.ERO.m});first sim. 
 auto;progress. smt(@List). smt(@SmtMap). rewrite (H11 i_R2). trivial. smt(@List).
 
@@ -5284,7 +5286,7 @@ if => //;auto;progress.
 wp;while(={BP.setidents, tpk, pPk, pTr, tsk, pCo, pOp, trL, pi2} /\ i0{1} = i{2}); first sim. 
 wp;while(={BP.setidents, tpk, trL, pTr, glob CP, pPk} /\ i0{1} = i{2}); first sim. 
 wp;rnd;while(={BP.setidents, tpk, tpTr, trL} /\ i0{1} = i{2}); first sim. 
-wp;rnd;wp;call(Ev_kgen_get_epk HRO.ERO). 
+wp;rnd;wp;call(Ev_kgen_get_epk). 
 wp;call(_:true);while(={w, HRO.ERO.m});first sim. 
 auto;progress. smt(@List). smt(@SmtMap). rewrite (H11 i_R2); first trivial. smt(@List).
 

--- a/du_mb_bpriv/Selene_with_signatures/SeleneBpriv_sign.ec
+++ b/du_mb_bpriv/Selene_with_signatures/SeleneBpriv_sign.ec
@@ -2851,11 +2851,22 @@ call(_:true); first by auto.
 if{2} => //. wp. 
 exists* (glob Ev){1}, BP.sk{1}, id{1}, ev{1}; elim* => gev sk id ev.
 call{1} (Edec_Odec_vo gev sk.`2 id ev). auto;progress.
+ 
+
 
 move: H6; rewrite mapP /drop_last_of4 //=; elim => x [Hxm [Hx1 [Hx2 Hx3]]].
 have Ho:= H2 x.`1 x.`3 x.`4 _; first by smt().
 
-smt(@List @SmtMap).
+have H6 : Some (oget (dec_cipher_vo BP.sk{2}.`2 (nth witness BP.bb'{2} j{2}).`1.`1
+               (nth witness BP.bb'{2} j{2}).`2 HRO.ERO.m{2})) =
+          Some (oget (onth (odflt [] BP.vmap{2}.[(nth witness BP.bb'{2} j{2}).`1.`1])
+               (find (fun (x0 : cipher * (cipher * signature) * vote * vote) =>
+               x0.`1 = (nth witness BP.bb'{2} j{2}).`2)
+               (odflt [] BP.vmap{2}.[(nth witness BP.bb'{2} j{2}).`1.`1])))).`4. 
+
+rewrite (H2 (nth witness BP.bb'{2} j{2}).`1.`1 (nth witness BP.bb'{2} j{2}).`2 x.`4); 1: smt(). 
+by rewrite -some_oget; 1: by smt().  
+smt(). 
 
 call(_: ={glob HRO.ERO}).  sim. auto;progress. 
 
@@ -3459,7 +3470,7 @@ case (ev{2} = (nth witness BP.bb0{2} i).`3) => Hev //=.
     rewrite /drop_last_of4 Hev Hid_bb0 Hpc_bb0 //=. 
     smt(@List). 
   move: Hdec; rewrite Hid -H12.
-  smt(someI). 
+  smt().
 
 have ->: !(find (fun (x : cipher * (cipher * signature) * vote * vote) =>
                x.`1 = (nth witness BP.bb0{2} i).`3) (odflt [] BP.vmap{1}.[id4]) 
@@ -3647,14 +3658,17 @@ seq 1 1 : (
       by done.
     case ( (pc, c, s1) \in (take i0{2} bb{2})); first by smt(). 
     move => not_in_take. 
-    have ? : (pc, c, s1) = nth witness bb{2} i0{2}. 
+    have H11 : (pc, c, s1) = nth witness bb{2} i0{2}. 
     + have H11 : (pc, c, s1) \in take (i0{2} + 1) bb{2} by smt().  
       have H12 : take (i0{2}+1) bb{2} = rcons (take i0{2} bb{2}) (nth witness bb{2} i0{2}). 
       + rewrite (take_nth witness i0{2} bb{2}). 
         + smt().  
         by done.  
-      smt(@List). 
-    smt(@SmtMap @List). 
+      smt(@List).  
+    have H12 : (pc, c, s1) = ((id0{2}, upk0{2}, supk0{2}, ct0{2}), ev0{2}, s0{2}) by rewrite H11 H0.  
+    have -> : pc.`1 = id0{2} by smt(). 
+    have -> : pc = (id0{2}, upk0{2}, supk0{2}, ct0{2}) by smt().
+    done.  
 
 auto;progress. smt(). rewrite (H4 id00 c (oget BP.pubmap{2}.[id00])). exact/H18.  trivial.  
 rewrite H9.  exact H18. trivial. 
@@ -3824,7 +3838,7 @@ while{1} ( ={BP.bb, BP.bb0, BP.bb1}
     move: H12. 
     smt(@List).
   + move: H11; rewrite size_cat //=; move => H11.
-    rewrite map_cat nth_cat.   
+    rewrite map_cat nth_cat.    
     case (i1 < size bb'{hr}). 
     + smt(size_map).
     move => Hn.
@@ -3835,7 +3849,6 @@ while{1} ( ={BP.bb, BP.bb0, BP.bb1}
              = ((nth witness BP.bb{m0} i1).`1, (nth witness BP.bb{m0} i1).`2).
     + rewrite (nth_map witness); first smt().
       by rewrite /drop_last_of3. 
-    print nth_map.
     rewrite -(nth_map witness witness drop_last_of3). 
     + rewrite index_ge0. smt (index_mem size_map).
     smt(). 
@@ -3844,14 +3857,20 @@ while{1} ( ={BP.bb, BP.bb0, BP.bb1}
   + smt(size_cat nth_cat).
   + smt(size_cat nth_cat).
   + move: H11; rewrite size_cat //=; move => H11.
-    rewrite map_cat nth_cat.   
+    rewrite map_cat nth_cat.     
     case (i1 < size bb'{hr}). 
     + smt(size_map).
     move => Hn.
     have Hx: i1 = size bb'{hr} by smt().
     move: H12 H9; rewrite size_map -Hx //=. 
     move => H12 H9. 
-    smt(@List).
+    rewrite /drop_last_of3 in H12. 
+    rewrite /drop_last_of3 in H9. 
+    rewrite (nth_map witness witness 
+            (fun (x: (ident * upkey * supkey * commitment) * cipher * signature), (x.`1, x.`2)) i1 BP.bb{m0}) 
+            in H12; 1:smt(). 
+    smt().  
+
   + move: H11; rewrite size_cat //=; move => H11.
     rewrite map_cat nth_cat.   
     case (i1 < size bb'{hr}). 
@@ -4370,7 +4389,10 @@ while{1} ( ={BP.bb, BP.bb0, BP.bb1}
     have Hx: i1 = size bb'{hr} by smt().
     move: H12 H9; rewrite size_map -Hx //=. 
     move => H12 H9. 
-    smt(@List).
+    rewrite /drop_last_of3 in H12. 
+    rewrite /drop_last_of3 in H9. 
+    rewrite (nth_map witness witness (fun (x:(ident*upkey*supkey*commitment)*cipher*signature), (x.`1, x.`2)) i1 BP.bb{m0}) in H12; 1: by smt(). 
+    smt().      
   + move: H11; rewrite size_cat //=; move => H11.
     rewrite map_cat nth_cat.   
     case (i1 < size bb'{hr}). 
@@ -5073,8 +5095,22 @@ wp;sp.
 exists* (glob Ev), BS.sk{hr}, l, c3. elim* => gev sk l c3.  
 call (Edec_Odec_vo gev sk l c3).
 auto;progress. smt(). smt().    
-smt(@List @SmtMap). 
- smt(). smt(). smt(). smt(@List). smt(). 
+rewrite (take_nth witness i1{hr} cL0{hr}); 1:done. 
+rewrite -cats1 -H map_cat.
+have -> : map (fun (b1 : cipher * ident) =>
+              if ! ((b1.`1, b1.`2) \in BS.encL{hr}) then
+                dec_cipher_vo BS.sk{hr} b1.`2 b1.`1 HRO.ERO.m{hr}
+             else None) [(c3{hr}, l{hr})] = [None] by smt(). 
+done. 
+ smt(). smt(). smt(). 
+rewrite (take_nth witness i1{hr} cL0{hr}); 1:done. 
+rewrite -cats1 -H map_cat.
+have -> : map (fun (b1 : cipher * ident) =>
+              if ! ((b1.`1, b1.`2) \in BS.encL{hr}) then
+                dec_cipher_vo BS.sk{hr} b1.`2 b1.`1 HRO.ERO.m{hr}
+             else None) [(c3{hr}, l{hr})] = 
+           [dec_cipher_vo BS.sk{hr} l{hr} c3{hr} HRO.ERO.m{hr}] by smt(). 
+ done. smt(). 
 auto;progress. 
 + by rewrite size_ge0. 
 + by rewrite take0.  
@@ -5379,18 +5415,24 @@ wp;sp.
 exists* (glob Ev), BS.sk{hr}, l, c3. elim* => gev sk l c3.  
  call (Edec_Odec_vo gev sk l c3).
 auto;progress. smt(). smt().    
-smt(@List @SmtMap). 
- smt(). smt(). smt(). smt(@List). smt().  
+rewrite (take_nth witness i1{hr} cL0{hr}); 1:done. 
+rewrite -cats1 -H map_cat. 
+smt(@List). 
+ smt(). smt(). smt(). 
+rewrite (take_nth witness i1{hr} cL0{hr}); 1:done. 
+rewrite -cats1 -H map_cat. 
+smt(@List). 
+smt().  
 auto;progress. 
 + by rewrite size_ge0. 
 + by rewrite take0.  
 + smt(). 
 + have Hi: i1_R = size BP.bb{2} by smt(size_map).
-  smt( take_size).
+smt(take_size). 
 qed.
 
 
-(**** Some useful lemmas for the final SMT call ****)
+(**** Some useful lemmas for the final lemma ****)
 local lemma G2L_G3R_cca &m : 
     BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
     `| Pr[G2L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res] - 
@@ -5412,25 +5454,8 @@ by rewrite -(G2R_G3R_equiv &m id_union) -(G1R_G2R_equiv &m id_union)
            -(G0R_G1R_equiv &m id_union) -(G0R'_G0R_equiv &m id_union) 
             (DU_MB_BPRIV_R_G0R'_equiv &m id_union). 
 qed. 
-
-local lemma DU_MB_BPRIV_L_G1L_equiv &m :
-    BP.setidents{m} = BP.setH{m} `|`BP.setD{m} =>
-    Pr[DU_MB_BPRIV_L(Selene(Ev,P,Ve,C,CP,SS),A,HRO.ERO,G).main() @ &m : res] = 
-    Pr[G0L(Ev,P,Ve,C,CP,SS,A,HRO.ERO,G).main() @ &m : res]. 
-proof. 
-move => id_union. 
-by rewrite (DU_MB_BPRIV_L_G0L'_equiv &m id_union) (G0L'_G0L_equiv &m id_union). 
-qed. 
-
-local lemma G1L_IND1CCA_L_equiv &m :
-    BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
-    Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res] = 
-    Pr[Ind1CCA(Ev,BCCA(Selene(Ev,P,Ve,C,CP,SS),SS,CP,A,S),HRO.ERO,Left).main() @ &m : res]. 
-proof. 
-move => id_union. 
-by rewrite (G1L_G2L_equiv &m id_union) (G2L_CCA_left_equiv &m id_union). 
-qed. 
  
+
 lemma du_mb_bpriv &m : 
   BP.setidents{m} = BP.setH{m} `|` BP.setD{m} =>
   `| Pr[DU_MB_BPRIV_L(Selene(Ev,P,Ve,C,CP,SS),A,HRO.ERO,G).main() @ &m : res]
@@ -5446,28 +5471,40 @@ proof.
 move => id_union. 
 
 (** Add and subtract G1L to the first absolute value **)
-have -> : `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G).main() @ &m : res]
-          - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
-           = 
-          `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G).main() @ &m : res]
-          - Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]
-          + Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]
-          - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
+have -> : 
+    `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP, SS), A, HRO.ERO, G).main() @ &m : res]
+    - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP, SS), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
+  = `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP, SS), A, HRO.ERO, G).main() @ &m : res]
+    - Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]
+    + Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]
+    - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP, SS), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
   by smt().  
  
-(** Triangle inequality **)
-have triang : 
-      `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G).main() @ &m : res] 
-      - Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]
-      + Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]
-      - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G, S, Recover').main () @ &m : res]| 
-      <=
-      `|Pr[DU_MB_BPRIV_L(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G).main() @ &m : res]
-      - Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res]| 
-    + `|Pr[G1L(Ev,Ve,C,CP,SS,A,HRO.ERO,S).main() @ &m : res] 
-      - Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP,SS), A, HRO.ERO, G, S, Recover').main () @ &m : res]|
-  by smt(@Real). 
-by smt. 
+rewrite (DU_MB_BPRIV_L_G0L'_equiv &m); 1:done.
+rewrite (G0L'_G0L_equiv &m); 1:done.  
+
+have H0 : `|Pr[G0L(Ev, P, Ve, C, CP, SS, A, HRO.ERO, G).main() @ &m : res] -
+            Pr[G1L(Ev, Ve, C, CP, SS, A, HRO.ERO, S).main() @ &m : res]| +
+          `|Pr[G1L(Ev, Ve, C, CP, SS, A, HRO.ERO, S).main() @ &m : res] -
+            Pr[DU_MB_BPRIV_R(Selene(Ev, P, Ve, C, CP, SS), A, HRO.ERO, G, S, Recover').main() @ &m : res]| <=
+            Pr[VFRS(Ev, BVFR(Selene(Ev, P, Ve, C, CP, SS), A, CP, SS), R, CP, SS, HRO.ERO, G).main() @ &m : res] +
+            Pr[VFRS(Ev, BVFR(Selene(Ev, P, Ve, C, CP, SS), A, CP, SS), R, CP, SS, HRO.ERO, S).main() @ &m : res] +
+          `|Pr[ZK_L(R(Ev, HRO.ERO), P, BZK(Ev, P, C, Ve, A, CP, SS, HRO.ERO), G).main() @ &m : res] -
+            Pr[ZK_R(R(Ev, HRO.ERO), S, BZK(Ev, P, C, Ve, A, CP, SS, HRO.ERO)).main() @ &m : res]| +
+          `|Pr[Ind1CCA(Ev, BCCA(Selene(Ev, P, Ve, C, CP, SS), SS, CP, A, S), HRO.ERO, Left).main() @ &m : res] -
+            Pr[Ind1CCA(Ev, BCCA(Selene(Ev, P, Ve, C, CP, SS), SS, CP, A, S), HRO.ERO, Right).main() @ &m : res]|. 
+
+rewrite (DU_MB_BPRIV_R_G3R_equiv &m); 1:done. 
+
+have -> : `|Pr[G1L(Ev, Ve, C, CP, SS, A, HRO.ERO, S).main() @ &m : res] -
+            Pr[G3R(Ev, Ve, C, CP, SS, A, HRO.ERO, S).main() @ &m : res]| = 
+          `|Pr[G2L(Ev, Ve, C, CP, SS, A, HRO.ERO, S).main() @ &m : res] -
+            Pr[G3R(Ev, Ve, C, CP, SS, A, HRO.ERO, S).main() @ &m : res]|
+  by rewrite (G1L_G2L_equiv &m). 
+
+rewrite (G2L_G3R_cca &m); 1:done.
+smt(G0L_G1L_zk_vfr).  
+smt(). 
 qed. 
 
 end section DU_MB_BPRIV. 

--- a/du_mb_bpriv/Selene_with_signatures/SeleneStrongConsistency_sign.ec
+++ b/du_mb_bpriv/Selene_with_signatures/SeleneStrongConsistency_sign.ec
@@ -248,17 +248,17 @@ module SConsis3_R(V:VotingSystem, Ex:Extractor, C:ValidIndS, A:SConsis3_adv,
 
 section StrongConsistency.
 
-declare module H  <: HOracle.Oracle { BP }. 
-declare module G  <: GOracle.Oracle { BP, H, HRO.ERO }. 
-declare module Ev <: PKEvo.Scheme { BP, H, G, HRO.ERO }.  
-declare module C  <: ValidIndS { BP, H, G, Ev, HRO.ERO }. 
-declare module P  <: Prover { BP, H, G, Ev, C }. 
-declare module Ve <: Verifier { BP, H, G, Ev, C, P }.
-declare module CP <: CommitmentProtocol { BP, H, G, Ev, C, P, Ve, HRO.ERO }.
-declare module SS <: SignatureScheme {BP, H, G, Ev, C, P, Ve, HRO.ERO, CP}.
+declare module H  <: HOracle.Oracle { -BP }. 
+declare module G  <: GOracle.Oracle { -BP, -H, -HRO.ERO }. 
+declare module Ev <: PKEvo.Scheme { -BP, -H, -G, -HRO.ERO }.  
+declare module C  <: ValidIndS { -BP, -H, -G, -Ev, -HRO.ERO }. 
+declare module P  <: Prover { -BP, -H, -G, -Ev, -C }. 
+declare module Ve <: Verifier { -BP, -H, -G, -Ev, -C, -P }.
+declare module CP <: CommitmentProtocol { -BP, -H, -G, -Ev, -C, -P, -Ve, -HRO.ERO }.
+declare module SS <: SignatureScheme {-BP, -H, -G, -Ev, -C, -P, -Ve, -HRO.ERO, -CP}.
 
-declare module Asc2 <: SConsis2_adv { BP, H, G, Ev, C, P, Ve, CP, SS, HRO.ERO }. 
-declare module Asc3 <: SConsis3_adv { BP, H, G, Ev, C, P, Ve, CP,SS }.  
+declare module Asc2 <: SConsis2_adv { -BP, -H, -G, -Ev, -C, -P, -Ve, -CP, -SS, -HRO.ERO }. 
+declare module Asc3 <: SConsis3_adv { -BP, -H, -G, -Ev, -C, -P, -Ve, -CP, -SS }.  
 
 (* useful lemmas *)
 lemma duni_ap_weight (l : 'a list) : weight (duniform (allperms l)) = 1%r.  
@@ -306,11 +306,11 @@ declare axiom SS_s_ll : islossless SS.sign.
 declare axiom SS_g_ll : islossless SS.gen.
 
 (* SConis2 adversary *)
-declare axiom Asc2_ll (O <: SCons_Oracle {Asc2}) : 
+declare axiom Asc2_ll (O <: SCons_Oracle {-Asc2}) : 
   islossless H.o => islossless G.o => islossless Asc2(O).main. 
 
 (* SConsis3 adversary *)
-declare axiom Asc3_ll (O <: SCons_Oracle {Asc3}) : 
+declare axiom Asc3_ll (O <: SCons_Oracle {-Asc3}) : 
   islossless H.o => islossless G.o => islossless Asc3(O).main. 
 
 (* Concrete extractor taking a ballot (pc, c) and secret data BP.sk *)

--- a/du_mb_bpriv/Selene_with_signatures/VotingDefinition_mb_sign.ec
+++ b/du_mb_bpriv/Selene_with_signatures/VotingDefinition_mb_sign.ec
@@ -64,7 +64,7 @@ module type  VotingSystem(H:HOracle.POracle, G:GOracle.POracle) = {
   proc validboard(bb:(pubcred * ballot * saux) list, pk:pkey) : bool { H.o }
 
   (**** Tally, returing the result of the election along with a proof of correct tally ****)
-  proc tally(bb:(pubcred * ballot * saux) list, pk:pkey, sk:skey) : result * prf { H.o G.o }
+  proc tally(bb:(pubcred * ballot * saux) list, pk:pkey, sk:skey) : result * prf { H.o, G.o }
 
   (**** Verify vote can capture checking encrypted ballots or plaintext results ****)
   proc verifyvote(id:ident, 
@@ -73,7 +73,7 @@ module type  VotingSystem(H:HOracle.POracle, G:GOracle.POracle) = {
                   bb:(pubcred * ballot * saux) list, 
                   bbstar:result * prf,
                   pc:pubcred,
-                  sc:secretcred) : bool { H.o G.o }
+                  sc:secretcred) : bool { H.o, G.o }
 
   (**** Verify that the proof of correct tally is valid ****)
   proc verifytally(st : (pkey * pubBB * result), pf:prf) : bool { G.o }

--- a/du_mb_bpriv/Selene_with_signatures/VotingSecurity_mb_sign.ec
+++ b/du_mb_bpriv/Selene_with_signatures/VotingSecurity_mb_sign.ec
@@ -173,17 +173,17 @@ module type DU_MB_BPRIV_adv(O:DU_MB_BPRIV_oracles) = {
                  cu:(ident, secretcred) fmap, 
                  pu:(ident, pubcred) fmap,
                  hc: ident fset ) 
-                 : (pubcred * ballot * saux) list { O.vote O.board O.h O.g }
+                 : (pubcred * ballot * saux) list { O.vote, O.board, O.h, O.g }
 
   (* adversary gets to see the tally and outputs a result and proof *)
-  proc get_tally(r:result, pi:prf) : result * prf { O.board O.h O.g } 
+  proc get_tally(r:result, pi:prf) : result * prf { O.board, O.h, O.g } 
 
   (* adversary gets to make an inital guess after seeing either bb0 or bb1 *)
-  proc initial_guess() : bool { O.h O.g }  
+  proc initial_guess() : bool { O.h, O.g }  
 
   (* adversary gets access to verify oracle and gets to make a guess based
      on what he sees, i.e. who are happy etc. *)
-  proc final_guess() : bool { O.verify O.h O.g }
+  proc final_guess() : bool { O.verify, O.h, O.g }
                                                                     
 }.
 

--- a/du_mb_bpriv/VotingDefinition/VotingDefinition_mb.ec
+++ b/du_mb_bpriv/VotingDefinition/VotingDefinition_mb.ec
@@ -64,7 +64,7 @@ module type  VotingSystem(H:HOracle.POracle, G:GOracle.POracle) = {
   proc validboard(bb:(pubcred * ballot) list, pk:pkey) : bool { H.o }
 
   (**** Tally, returing the result of the election along with a proof of correct tally ****)
-  proc tally(bb:(pubcred * ballot) list, pk:pkey, sk:skey) : result * prf { H.o G.o }
+  proc tally(bb:(pubcred * ballot) list, pk:pkey, sk:skey) : result * prf { H.o, G.o }
 
   (**** Verify vote can capture checking encrypted ballots or plaintext results ****)
   proc verifyvote(id:ident, 
@@ -73,7 +73,7 @@ module type  VotingSystem(H:HOracle.POracle, G:GOracle.POracle) = {
                   bb:(pubcred * ballot) list, 
                   bbstar:result * prf,
                   pc:pubcred,
-                  sc:secretcred) : bool { H.o G.o }
+                  sc:secretcred) : bool { H.o, G.o }
 
   (**** Verify that the proof of correct tally is valid ****)
   proc verifytally(st : (pkey * pubBB * result), pf:prf) : bool { G.o }

--- a/du_mb_bpriv/VotingDefinition/VotingSecurity_mb.ec
+++ b/du_mb_bpriv/VotingDefinition/VotingSecurity_mb.ec
@@ -169,17 +169,17 @@ module type DU_MB_BPRIV_adv(O:DU_MB_BPRIV_oracles) = {
                  cu:(ident, secretcred) fmap, 
                  pu:(ident, pubcred) fmap,
                  hc: ident fset ) 
-                 : (pubcred * ballot) list { O.vote O.board O.h O.g }
+                 : (pubcred * ballot) list { O.vote, O.board, O.h, O.g }
 
   (* adversary gets to see the tally and outputs a result and proof *)
-  proc get_tally(r:result, pi:prf) : result * prf { O.board O.h O.g } 
+  proc get_tally(r:result, pi:prf) : result * prf { O.board, O.h, O.g } 
 
   (* adversary gets to make an inital guess after seeing either bb0 or bb1 *)
-  proc initial_guess() : bool { O.h O.g }  
+  proc initial_guess() : bool { O.h, O.g }  
 
   (* adversary gets access to verify oracle and gets to make a guess based
      on what he sees, i.e. who are happy etc. *)
-  proc final_guess() : bool { O.verify O.h O.g }
+  proc final_guess() : bool { O.verify, O.h, O.g }
                                                                     
 }.
 

--- a/mb_bpriv_original_def/Belenios_omb.ec
+++ b/mb_bpriv_original_def/Belenios_omb.ec
@@ -169,18 +169,18 @@ module (Belenios (Pe: PSpke.Prover, Ve: PSpke.Verifier, Vc: PSpke.Verifier,
 
 section MB_BPRIV. 
 
-declare module Pe <: PSpke.Prover    {BP, HRO.ERO, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv}.
-declare module Ve <: PSpke.Verifier  {BP, HRO.ERO, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv, Pe}.
-declare module Vc <: PSpke.Verifier  {BP, HRO.ERO, BPS, BS, Pe, Ve}.
+declare module Pe <: PSpke.Prover    { -BP, -HRO.ERO, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv }.
+declare module Ve <: PSpke.Verifier  { -BP, -HRO.ERO, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv, -Pe }.
+declare module Vc <: PSpke.Verifier  { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve }.
 
-declare module G  <: GOracle.Oracle  {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc}.   
-declare module S  <: Simulator       {BP, HRO.ERO, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv, 
-                                     Pe, Ve, Vc, G}. 
-declare module Vz <: Verifier        {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S}. 
-declare module Pz <: Prover          {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S, Vz}. 
-declare module R  <: VotingRelation' {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S, Vz, Pz}. 
+declare module G  <: GOracle.Oracle  { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc }.
+declare module S  <: Simulator       { -BP, -HRO.ERO, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv, 
+                                       -Pe, -Ve, -Vc, -G }. 
+declare module Vz <: Verifier        { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S }. 
+declare module Pz <: Prover          { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S, -Vz }. 
+declare module R  <: VotingRelation' { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S, -Vz, -Pz }. 
  
-declare module A  <: OMB_BPRIV_adv    {BP, HRO.ERO, BPS, BS, Pe, Ve, Vc, G, S, Vz, Pz, R}. 
+declare module A  <: OMB_BPRIV_adv   { -BP, -HRO.ERO, -BPS, -BS, -Pe, -Ve, -Vc, -G, -S, -Vz, -Pz, -R }. 
 
 (**** Lossless assumptions ****)
 
@@ -189,48 +189,48 @@ declare axiom Gi_ll : islossless G.init.
 declare axiom Go_ll : islossless G.o. 
 
 (** MB-BPRIV adversary **)
-declare axiom A_a1_ll (O <: MB_BPRIV_oracles { A }):
+declare axiom A_a1_ll (O <: MB_BPRIV_oracles { -A }):
   islossless O.vote => 
   islossless O.board => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).a1. 
 
-declare axiom A_a2_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a2_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.board => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).a2.
  
-declare axiom A_a3_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a3_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.verify => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).a3. 
 
-declare axiom A_a4_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a4_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).a4. 
 
-declare axiom A_a5_ll (O <: MB_BPRIV_oracles { A }):
+declare axiom A_a5_ll (O <: MB_BPRIV_oracles { -A }):
   islossless O.board => 
   islossless O.h => 
   islossless O.g => 
   islossless A(O).a5. 
 
 (** Main Proof system **)
-declare axiom PS_p_ll (G <: GOracle.POracle ) : 
+declare axiom PS_p_ll (G <: GOracle.POracle { -Pz }) : 
   islossless G.o => islossless Pz(G).prove. 
-declare axiom PS_v_ll (G <: GOracle.POracle ) : 
+declare axiom PS_v_ll (G <: GOracle.POracle { -Vz }) : 
   islossless G.o => islossless Vz(G).verify. 
 
 (** Enc Proof system **)
-declare axiom PE_p_ll (H <: HOracle.POracle) : 
+declare axiom PE_p_ll (H <: HOracle.POracle { -Pe }) : 
   islossless H.o => islossless Pe(H).prove. 
-declare axiom PE_v_ll (H <: HOracle.POracle) : 
+declare axiom PE_v_ll (H <: HOracle.POracle { -Ve }) : 
   islossless H.o => islossless Ve(H).verify.
-declare axiom PE_c_ll (H <: HOracle.POracle) : 
+declare axiom PE_c_ll (H <: HOracle.POracle { -Vc }) : 
   islossless H.o => islossless Vc(H).verify.
 
 (** ZK simulator **)
@@ -299,7 +299,7 @@ proof.
   by auto=>/>; rewrite FDistr.dt_ll.
 qed.
 
-local lemma E_enc_ll (H <: HOracle.POracle ) : 
+local lemma E_enc_ll (H <: HOracle.POracle { -Pe }) : 
   islossless H.o => islossless IPKE(Pe,Ve, H).enc. 
 proof.
   move => Ho_ll.
@@ -318,7 +318,7 @@ qed.
  
 
 (** ValidInd operator **)
-local lemma C_vi_ll (H <: HOracle.POracle ) : 
+local lemma C_vi_ll (H <: HOracle.POracle { -Vc }) : 
   islossless H.o => islossless CV(Vc,H).validInd. 
 proof.
   move => Ho_ll; proc. 
@@ -526,10 +526,13 @@ proof.
   = Pr[OMB_BPRIV_R(MV(IPKE(Pe, Ve), Pz, Vz, CV(Vc)), A, HRO.ERO, G, S, Recover').main() @ &m : res]
     by byequiv =>/>; sim.
 
-  by rewrite (mb_bpriv G (IPKE(Pe,Ve)) S Vz Pz R (CV(Vc)) A Gi_ll Go_ll A_a1_ll A_a2_ll 
-               A_a3_ll A_a4_ll A_a5_ll PS_p_ll PS_v_ll E_kg_ll E_enc_ll E_dec_ll Si_ll So_ll 
+  rewrite (mb_bpriv G (IPKE(Pe,Ve)) S Vz Pz R (CV(Vc)) A Gi_ll Go_ll A_a1_ll A_a2_ll 
+               A_a3_ll A_a4_ll A_a5_ll PS_p_ll PS_v_ll _ _ _ Si_ll So_ll 
                Sp_ll R_m_ll C_vi_ll Rho_weight E_kgen_extractpk relConstraint 
                Ekgen_extractPk Edec_Odec Ee_eq Eenc_decL Eenc_dec2 Ee_eq2 &m IHD). 
+  + by move=> H H_o_ll; exact: (E_kg_ll H).
+  + by move=> H H_o_ll; exact: (E_enc_ll H).
+  by move=> H H_o_ll; exact: (E_dec_ll H).
 qed.
 
 end section MB_BPRIV. 

--- a/mb_bpriv_original_def/MiniVotingSecurity_omb.ec
+++ b/mb_bpriv_original_def/MiniVotingSecurity_omb.ec
@@ -18,14 +18,14 @@ clone include ROM with
 (****** MB-BPRIV *******)
 section MB_BPRIV. 
 
-declare module G  <: GOracle.Oracle { BP, HRO.ERO, BPS, BS }.   
-declare module E  <: Scheme { BP, HRO.ERO, G, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv}. 
-declare module S  <: Simulator { BP, HRO.ERO, G, E, BPS, BS, PKEvf.H.Count, PKEvf.H.HybOrcl, WrapAdv }. 
-declare module Ve <: Verifier { BP, HRO.ERO, G, E, S, BPS, BS }. 
-declare module P  <: Prover { BP, HRO.ERO, G, E, S, Ve, BPS, BS }. 
-declare module R  <: VotingRelation' { BP, HRO.ERO, G, E, S, Ve, P, BPS, BS }. 
-declare module C  <: ValidInd { BP, HRO.ERO, G, E, S, Ve, P, R, BPS, BS }. 
-declare module A  <: OMB_BPRIV_adv { BP, HRO.ERO, G, E, S, Ve, P, R, C, BPS, BS}. 
+declare module G  <: GOracle.Oracle { -BP, -HRO.ERO, -BPS, -BS }.   
+declare module E  <: Scheme { -BP, -HRO.ERO, -G, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv }.
+declare module S  <: Simulator { -BP, -HRO.ERO, -G, -E, -BPS, -BS, -PKEvf.H.Count, -PKEvf.H.HybOrcl, -WrapAdv }. 
+declare module Ve <: Verifier { -BP, -HRO.ERO, -G, -E, -S, -BPS, -BS }. 
+declare module P  <: Prover { -BP, -HRO.ERO, -G, -E, -S, -Ve, -BPS, -BS }. 
+declare module R  <: VotingRelation' { -BP, -HRO.ERO, -G, -E, -S, -Ve, -P, -BPS, -BS }. 
+declare module C  <: ValidInd { -BP, -HRO.ERO, -G, -E, -S, -Ve, -P, -R, -BPS, -BS }. 
+declare module A  <: OMB_BPRIV_adv { -BP, -HRO.ERO, -G, -E, -S, -Ve, -P, -R, -C, -BPS, -BS }. 
 
 (**** Lossless assumptions ****)
 
@@ -34,25 +34,25 @@ declare axiom Gi_ll : islossless G.init.
 declare axiom Go_ll : islossless G.o. 
 
 (** MB-BPRIV adversary **) 
-declare axiom A_a1_ll (O <: MB_BPRIV_oracles { A }):
+declare axiom A_a1_ll (O <: MB_BPRIV_oracles { -A }):
   islossless O.vote => islossless O.board => islossless O.h => islossless O.g => islossless A(O).a1. 
-declare axiom A_a2_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a2_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.board => islossless O.h => islossless O.g => islossless A(O).a2. 
-declare axiom A_a3_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a3_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.verify => islossless O.h => islossless O.g => islossless A(O).a3. 
-declare axiom A_a4_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a4_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.h => islossless O.g => islossless A(O).a4.
-declare axiom A_a5_ll (O <: MB_BPRIV_oracles { A }): 
+declare axiom A_a5_ll (O <: MB_BPRIV_oracles { -A }): 
   islossless O.board => islossless O.h => islossless O.g => islossless A(O).a5.
 
 (** Proof system **)
-declare axiom PS_p_ll (G <: GOracle.POracle) : islossless G.o => islossless P(G).prove. 
-declare axiom PS_v_ll (G <: GOracle.POracle) : islossless G.o => islossless Ve(G).verify. 
+declare axiom PS_p_ll (G <: GOracle.POracle { -P }) : islossless G.o => islossless P(G).prove. 
+declare axiom PS_v_ll (G <: GOracle.POracle { -Ve }) : islossless G.o => islossless Ve(G).verify. 
 
 (** Encryption **)
-declare axiom E_kg_ll  (H <: HOracle.POracle) : islossless H.o => islossless E(H).kgen. 
-declare axiom E_enc_ll (H <: HOracle.POracle) : islossless H.o => islossless E(H).enc. 
-declare axiom E_dec_ll (H <: HOracle.POracle) : islossless H.o => islossless E(H).dec. 
+declare axiom E_kg_ll  (H <: HOracle.POracle { -E }) : islossless H.o => islossless E(H).kgen. 
+declare axiom E_enc_ll (H <: HOracle.POracle { -E }) : islossless H.o => islossless E(H).enc. 
+declare axiom E_dec_ll (H <: HOracle.POracle { -E }) : islossless H.o => islossless E(H).dec. 
 
 (** Encryption with HRO.ERO **)
 local lemma E_kg_ll'  : islossless HRO.ERO.o => islossless E(HRO.ERO).kgen
@@ -71,7 +71,7 @@ declare axiom Sp_ll : islossless S.prove.
 declare axiom R_m_ll : islossless R(E,HRO.ERO).main. 
 
 (** ValidInd operator **)
-declare axiom C_vi_ll (H <: HOracle.POracle) : islossless H.o => islossless C(H).validInd. 
+declare axiom C_vi_ll (H <: HOracle.POracle { -C }) : islossless H.o => islossless C(H).validInd. 
 
 (****************************************************************************************************)
 (*************************** Necessary axioms and small lemmas **************************************)
@@ -176,8 +176,8 @@ op rem_fst4 (x : ('a * 'b * 'c * 'd)) = (x.`2, x.`3, x.`4).
 
 (************ Construct a ZK adversary from MB-BPRIV adversary *************) 
 module type VotingAdvZK (H:HOracle.Oracle, O:GOracle.POracle) = {
-  proc a1() : (pkey * pubBB * result) * (skey * (ident * cipher) list) {H.init H.o O.o}
-  proc a2(pi : prf option) : bool {H.o O.o}
+  proc a1() : (pkey * pubBB * result) * (skey * (ident * cipher) list) {H.init, H.o, O.o}
+  proc a2(pi : prf option) : bool {H.o, O.o}
 }.
 
 (********  BZK with valid as global variable BP.valid from the BP module  ********)
@@ -504,7 +504,7 @@ local module G0L' (E:Scheme, P:Prover, Ve:Verifier, C:ValidInd,
 
 
 (*** Lemma proving that G0L' is perfectly equivalent to the original definition ***)
-local lemma MB_BPRIV_L_G0L'_equiv &m (H <: HOracle.Oracle{E, BP, G, A, C, Ve, P}) : 
+local lemma MB_BPRIV_L_G0L'_equiv &m (H <: HOracle.Oracle{ -E, -BP, -G, -A, -C, -Ve, -P}) : 
     Pr[OMB_BPRIV_L(MV(E, P, Ve, C), A, H, G).main() @ &m : res] = 
     Pr[G0L'(E,P,Ve,C,A,H,G).main() @ &m : res].
 proof.
@@ -910,7 +910,7 @@ local module G1L (E:Scheme, Ve:Verifier, C:ValidInd, A:OMB_BPRIV_adv, H:HOracle.
 
 (*** Losslessness for BZK, useful in the ZK part a bit further down  ***)
 
-local lemma BZK_a1_ll (H <: HOracle.Oracle {A, BP}) (G <: GOracle.POracle {A, BP}) : 
+local lemma BZK_a1_ll (H <: HOracle.Oracle { -A, -BP }) (G <: GOracle.POracle { -A, -BP }) : 
  islossless H.init =>  islossless H.o => 
  islossless G.o => islossless BZK(E, P, C, Ve, A, H, G).a1. 
 proof. 
@@ -1005,7 +1005,7 @@ call(_:true);wp;skip.
   qed. 
 
 
-lemma BZK_a2_ll (H <: HOracle.Oracle {A, BP}) (G <: GOracle.POracle {A, BP}) : 
+lemma BZK_a2_ll (H <: HOracle.Oracle { -A, -BP }) (G <: GOracle.POracle { -A, -BP }) : 
   islossless H.o =>
   islossless G.o => 
   islossless BZK(E,P,C,Ve,A,H,G).a2. 
@@ -1020,9 +1020,9 @@ qed.
     
 (************************************************************************)
 
-lemma BZK_a2_ll' (H <: HOracle.Oracle {A, BP}) 
-                 (G <: GOracle.POracle {A, H, BP})
-                 (P <: Prover {E, C, Ve, A, ZK_L, BPS, BP, H, G}) :
+lemma BZK_a2_ll' (H <: HOracle.Oracle { -A, -BP }) 
+                 (G <: GOracle.POracle { -A, -H, -BP })
+                 (P <: Prover { -E, -C, -Ve, -A, -ZK_L, -BPS, -BP, -H, -G }) :
   islossless H.o => 
   islossless G.o => 
   islossless P(G).prove =>
@@ -1134,8 +1134,8 @@ qed.
 (*** Lemma bounding the probability that the relation does not hold in ZK_L by ***)
 (*** the probability of returning true in the VFR game.                        ***)
 
-local lemma ZKL_rel &m (G <: GOracle.Oracle {A, BPS, BP, BS, Ve, E, HRO.ERO, R, C})
-                       (P <: Prover {E, C, Ve, A, R, BPS, BP, BS, HRO.ERO, G}) :
+local lemma ZKL_rel &m (G <: GOracle.Oracle { -A, -BPS, -BP, -BS, -Ve, -E, -HRO.ERO, -R, -C })
+                       (P <: Prover { -E, -C, -Ve, -A, -R, -BPS, -BP, -BS, -HRO.ERO, -G}) :
     islossless G.o => islossless P(G).prove =>
     Pr[ZK_L(R(E,HRO.ERO), P, BZK(E,P,C,Ve,A,HRO.ERO), G).main() @ &m : !BPS.rel] <=
     Pr[VFR(E, BVFR(MV(E,P,Ve,C), A), R(E), HRO.ERO, G).main() @ &m : res].  
@@ -1223,7 +1223,7 @@ qed.
 (*** Lemma bounding the probability that the relation does not hold in ZK_R by ***)
 (*** the probability of returning true in the VFR game.                        ***)
 
-local lemma ZKR_rel &m (S <: Simulator {E, C, P, Ve, A, R, BPS, BP, BS, HRO.ERO, G}) :
+local lemma ZKR_rel &m (S <: Simulator { -E, -C, -P, -Ve, -A, -R, -BPS, -BP, -BS, -HRO.ERO, -G }) :
     islossless S.o => islossless S.prove =>
     Pr[ZK_R(R(E,HRO.ERO), S, BZK(E,P,C,Ve,A,HRO.ERO) ).main() @ &m : !BPS.rel] <=
     Pr[VFR(E, BVFR(MV(E,P,Ve,C), A), R(E), HRO.ERO, S).main() @ &m : res].  
@@ -2120,7 +2120,7 @@ local module G0R' (E:Scheme, P:Prover, Ve:Verifier, C:ValidInd, A:OMB_BPRIV_adv,
 
 (******** Lemma proving that the above game is equivalent to security definition *******)
 
-local lemma MB_BPRIV_R_G0'_R_equiv &m (H <: HOracle.Oracle {E, BP, G, A, C, Ve, S, R, P}) : 
+local lemma MB_BPRIV_R_G0'_R_equiv &m (H <: HOracle.Oracle { -E, -BP, -G, -A, -C, -Ve, -S, -R, -P }) : 
   Pr[OMB_BPRIV_R(MV(E, P, Ve, C), A, H, G, S, Recover').main() @ &m : res] =
   Pr[G0R'(E, P, Ve, C, A, H, G, S).main() @ &m : res].
 proof.

--- a/mb_bpriv_original_def/MiniVotingSecurity_omb.ec
+++ b/mb_bpriv_original_def/MiniVotingSecurity_omb.ec
@@ -2928,9 +2928,11 @@ seq 2 2 :  (={glob A, glob C, glob Ve, glob S, glob E, glob HRO.ERO, BP.setHchec
       if{2} => //; wp. 
       exists* (glob E){1}, BP.sk{1}, idl{1}, b{1};elim* => ee sk1 idl1 b1;progress.
       call{1} (Edec_Odec ee sk1 idl1 b1). 
-      skip;progress. rewrite H1. apply H4. smt().
+      skip;progress. rewrite H1. apply H4.
+      by move: H H0=> <- />.
       exists* (glob E){1}, BP.sk{1}, idl{1}, b{1};elim* => ee sk1 idl1 b1;progress. 
-      call (Edec_Odec_eq sk1 idl1 b1);skip;progress;smt(). skip;trivial.
+      by call (Edec_Odec_eq sk1 idl1 b1); auto=> /> &2 <-.
+      skip;trivial.
       wp; rnd;trivial. auto;progress. 
 qed.       
 
@@ -4208,7 +4210,15 @@ while ( ={j, BP.bb, dbb, BP.vmap, glob HRO.ERO} /\ (0 <= j{2})
 
 wp;sp. 
   if{1} =>//=. 
-  + auto=>/>; progress. do 3! congr. smt(). do 4! congr. smt(). smt(). smt(). smt(). smt(). 
+  + auto=>/>; progress.
+    + do 3! congr.
+      + smt().
+      do 4! congr.
+      + smt().
+      by move: H; case: ((nth witness BP.bb j){2})=> /#.
+    + smt().
+    + smt().
+    smt(). 
   exists* (glob E){1}, BP.sk{1}, idl{1}, b{1};
     elim* => ge sk idl b. 
   call{1} (Edec_Odec ge sk idl b). 

--- a/mb_bpriv_original_def/VotingDefinition_omb.ec
+++ b/mb_bpriv_original_def/VotingDefinition_omb.ec
@@ -60,14 +60,14 @@ module type  VotingSystem(H:HOracle.POracle, G:GOracle.POracle) = {
   proc validboard(bb:(pubcred * ballot) list, pk:pkey) : bool { H.o }
 
   (* Tally algorithm *)
-  proc tally(bb:(pubcred * ballot) list, pk:pkey, sk:skey) : result * prf { H.o G.o }
+  proc tally(bb:(pubcred * ballot) list, pk:pkey, sk:skey) : result * prf { H.o, G.o }
 
   (* Verify vote algorithm that can capture checking encrypted ballots or plaintext results *)
   proc verifyvote(id:ident, 
                   s :state,
                   bb:(pubcred * ballot) list,
                   pc:pubcred,
-                  sc:secretcred) : bool { H.o G.o }
+                  sc:secretcred) : bool { H.o, G.o }
 
   (* Verify that the tally is correct *)
   proc verifytally(st : (pkey * pubBB * result), pi:prf) : bool { G.o }

--- a/mb_bpriv_original_def/VotingSecurity_omb.ec
+++ b/mb_bpriv_original_def/VotingSecurity_omb.ec
@@ -176,15 +176,15 @@ module type OMB_BPRIV_adv(O:MB_BPRIV_oracles) = {
   proc a1(pk:pkey, 
           cu:(ident, secretcred) fmap, 
           pu:(ident, pubcred) fmap ) : (pubcred * ballot) list 
-                                       { O.vote O.board O.h O.g }
+                                       { O.vote, O.board, O.h, O.g }
                                        
   proc a2() : bool { }
 
-  proc a3() : unit { O.verify O.h O.g }
+  proc a3() : unit { O.verify, O.h, O.g }
   
   proc a4() : bool { }
 
-  proc a5 (r:result, pi:prf) : bool { O.board O.h O.g }
+  proc a5 (r:result, pi:prf) : bool { O.board, O.h, O.g }
                                       
 }.
 


### PR DESCRIPTION
This brings the proof up to date with the current EC release (r2022.04).

This commit fixes syntax, but leaves SMT-related issues open.
There are also some hypotheses to refine in the final theorem and related lemmas.

This also augments the project file to check more of the proofs.